### PR TITLE
Bugfix_2024.08.03.20.36_本日の日付をクリックしたときのカレンダーによるソート機能が発火しない不具合を修正_#3

### DIFF
--- a/app/views/users/shuffled_overviews/_shuffled_overviews_count_calendar.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overviews_count_calendar.html.erb
@@ -76,7 +76,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const calendarContainer = document.querySelector('#shuffled_overviews_count_calendar');
   
   document.addEventListener('click', function(event) {
-    const target = event.target.closest('.previous, .next, .today');
+    const target = event.target.closest('.previous, .next, .today, .start-date');
     if (target) {
       event.preventDefault();
       const url = target.href;
@@ -99,7 +99,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function registerNavigationEvents() {
     // ナビゲーションリンクのイベントハンドラを再登録
-    document.querySelectorAll('.previous, .next, .today').forEach(link => {
+    document.querySelectorAll('.previous, .next, .today, .start-date').forEach(link => {
       link.addEventListener('click', event => {
         event.preventDefault();
         const url = event.target.href;
@@ -121,7 +121,56 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  registerNavigationEvents();
-});
-
+    function getFormattedDate(date) {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    }
+  
+    // 現在の日付を取得
+    const todayDate = new Date();
+    const formattedDate = getFormattedDate(todayDate);
+  
+    function registerNavigationEvents() {
+      document.querySelectorAll('.start-date').forEach(link => {
+        link.addEventListener('click', event => {
+          event.preventDefault();
+          const baseUrl = event.target.closest('a').href;
+          // URLのパスが"/filter_by_date" で終わる場合に追加する
+          const url = `${baseUrl.replace(/\/filter_by_date\/.*$/, '')}/filter_by_date/${formattedDate}`;
+  
+          fetch(url, {
+            headers: {
+              'X-Requested-With': 'XMLHttpRequest'
+            }
+          })
+          .then(response => response.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const newCalendar = doc.querySelector('#shuffled_overviews_count_calendar').innerHTML;
+            calendarContainer.innerHTML = newCalendar;
+  
+            // URLを更新
+            window.history.pushState({}, '', url);
+            window.location.reload();
+  
+            // Debug: check if shuffled-overview-list exists
+            const shuffledOverviewList = doc.querySelector('.shuffled-overview-list');
+            if (shuffledOverviewList) {
+              document.querySelector('.shuffled-overview-list').innerHTML = shuffledOverviewList.innerHTML;
+            } else {
+              console.error('Shuffled overview list element not found.');
+            }
+            registerNavigationEvents();
+          })
+          .catch(error => console.error('Error:', error));
+        });
+      });
+    }
+  
+    registerNavigationEvents();
+  });
+  
 </script>


### PR DESCRIPTION
## GitHub Issue Ticket

- https://github.com/maixhashi/plotforge/issues/3

## やった事

- このプルリクエストにて何をしたのか？
  - 作成日によるソート用のカレンダーで本日の日付をクリックしたときにソート機能が有効にならない不具合を修正
  - 本日以外の日ではソートできるのに本日ではソートできないという機能の不統一性を修正

### なぜやるのか

- GitHub Issue で説明できない捕捉的な事項 (Jira の説明で十分であればここは不要)
- なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい

## 動作確認

- どの環境でどんな動作チェックをしたか
  - development環境
  -  作成日によるソート用のカレンダーで本日の日付をクリックして、ソート機能が有効になることを確認

## Refs (レビューにあたって参考にすべき情報）(Optional)

- 関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報
  - .todayクラスがsimple_calendarで重複して使用されている
    - 今日の日付の月へ遷移するアイコンボタン
    - 今日の日付
  - 上記を鑑みて、.start-dateにfilter_by_dateメソッドを発火するためのjs関数の対象セレクタを変更
    - .todayクラス
    - .start-dateクラス
      - 変更着手前に.start_dateクラスになっていた。クラス名の不整合もソート機能が有効化しなかった原因の可能性？
