### PR TITLE
Feature 2024.08.03.21.17 shuffled overviewモデルレコードに伴う映画レコードのみを表示する機能 #6

### DIFF
--- a/app/controllers/shuffled_overviews_controller.rb
+++ b/app/controllers/shuffled_overviews_controller.rb
@@ -76,6 +76,31 @@ def filter_by_date
   end
 end
 
+def related_movies
+  @start_date = params.fetch(:start_date, Date.today)
+  
+  # 現在のユーザーのシャッフルされたあらすじを取得
+  @shuffled_overviews = current_user.shuffled_overviews
+
+  # 映画データを取得する
+  tmdb_service = TmdbService.new
+  @movies_data = {}
+  @shuffled_overviews.each do |shuffled_overview|
+    shuffled_overview.movie_ids.each do |movie_id|
+      @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
+    end
+  end
+
+  # あらすじのデータはビューに渡すが、表示には使わない
+  @grouped_overviews = current_user.shuffled_overviews.group_by_day(:created_at).count
+
+  respond_to do |format|
+    format.html # これで `related_movies.html.erb` がレンダリングされる
+    format.js   # 必要に応じてJSテンプレートも対応
+  end
+end
+
+
   private
 
   def set_user

--- a/app/views/shuffled_overviews/related_movies.html.erb
+++ b/app/views/shuffled_overviews/related_movies.html.erb
@@ -1,0 +1,34 @@
+<!-- app/views/shuffled_overviews/related_movies.html.erb -->
+<div class="movie-images">
+  <% @movies_data.each do |movie_id, movie| %>
+    <div class="movie-image">
+      <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+    </div>
+  <% end %>
+</div>
+
+<style>
+.movie-images {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-left: 10px;
+  margin-right: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: start /* 中央揃え */
+}
+
+.movie-image {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.movie-image img {
+  width: 150px;
+  height: auto;
+  object-fit: cover;
+  display: block;
+}
+</style>

--- a/app/views/users/shuffled_overviews/related_movies.js.erb
+++ b/app/views/users/shuffled_overviews/related_movies.js.erb
@@ -1,0 +1,1 @@
+document.querySelector('#movie-list-container').innerHTML = "<%= j render partial: 'related_movies', locals: { movies_data: @movies_data } %>";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     resources :shuffled_overviews, only: [:index, :create] do
       collection do
         get 'filter_by_date/:date', action: :filter_by_date, as: :filter_by_date
+        get 'related_movies', action: :related_movies, as: :related_movies
       end
     end
   end


### PR DESCRIPTION
## GitHub Issue Ticket
- https://github.com/maixhashi/plotforge/issues/6
  - https://github.com/maixhashi/plotforge/issues/8
  - https://github.com/maixhashi/plotforge/issues/9
  - https://github.com/maixhashi/plotforge/issues/10

## やった事

- ShuffledOverviewモデルレコードに関連する映画のみを表示する機能を実装

### なぜやるのか

- シャッフルされたあらすじ（ShuffledOverviewモデルレコード）から映画を選択できるユーザーエクスペリエンスの提供

## 動作確認

development環境
1.  http://localhost:3000/users/1/shuffled_overviews/related_movies にアクセス（URLを打ち込みでアクセス）
2. 映画の画像一覧が表示されることを確認

## Refs (レビューにあたって参考にすべき情報）(Optional)

- 関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報
  - https://github.com/maixhashi/plotforge/issues/10
    - ShuffledOverviewsController#indexで定義した@shuffled_overviewsをdisplay: none;にするのみだと、映画一覧の配置が想定しない配置になったため、viewも新たに作成。
```ruby
class ShuffledOverviewsController < ApplicationController
  def index
    @start_date = params.fetch(:start_date, Date.today) 
    
    @shuffled_overviews = current_user.shuffled_overviews
  
    # 映画データを取得する
    tmdb_service = TmdbService.new
    @movies_data = {}
    @shuffled_overviews.each do |shuffled_overview|
      shuffled_overview.movie_ids.each do |movie_id|
        @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
      end
    end
  
    @grouped_overviews = current_user.shuffled_overviews.group_by_day(:created_at).count
    
    render 'users/shuffled_overviews/index'
    respond_to do |format|
      format.html # index.html.erb
      format.js   # index.js.erb
    end
  end

``` 
