### PR TITLE
Feature_2024.08.03.22.48_ShuffledOverviewモデルレコードに関連する映画一覧の画面へのリンクアイコン…

### DIFF
--- a/app/views/shuffled_overviews/related_movies.html.erb
+++ b/app/views/shuffled_overviews/related_movies.html.erb
@@ -1,14 +1,14 @@
 <!-- app/views/shuffled_overviews/related_movies.html.erb -->
-<div class="movie-images">
+<div class="related-movie-images">
   <% @movies_data.each do |movie_id, movie| %>
-    <div class="movie-image">
+    <div class="related-movie-image">
       <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
     </div>
   <% end %>
 </div>
 
 <style>
-.movie-images {
+.related-movie-images {
   margin-top: 10px;
   margin-bottom: 10px;
   margin-left: 10px;
@@ -19,13 +19,13 @@
   justify-content: start /* 中央揃え */
 }
 
-.movie-image {
+.related-movie-image {
   display: flex;
   justify-content: center;
   align-items: center;
 }
 
-.movie-image img {
+.related-movie-image img {
   width: 150px;
   height: auto;
   object-fit: cover;

--- a/app/views/users/shuffled_overviews/index.html.erb
+++ b/app/views/users/shuffled_overviews/index.html.erb
@@ -11,8 +11,15 @@
   <img id="popup-image" src="" alt="Movie Image">
 </div>
 
-<div class="calendar-toggle" id="calendar-icon">
-  <i class="fa fa-3x fa-calendar"></i>
+<div class="link-icon-container">
+  <div class="calendar-toggle" id="calendar-icon">
+    <i class="fa fa-3x fa-calendar"></i>
+  </div>
+  <div>
+    <%= link_to related_movies_user_shuffled_overviews_path, class:"link-to-related-movies" do %>
+      <i class="fa fa-3x fa-film"></i>
+    <% end %>
+  </div>
 </div>
 
 
@@ -20,10 +27,18 @@
 <style>
 .calendar-toggle {
   position: fixed;
+  bottom: 140px; /* ヘッダーの高さに応じて調整 */
+  right: 30px;
+  z-index: 1000;
+  cursor: pointer;
+}
+.link-to-related-movies {
+  position: fixed;
   bottom: 70px; /* ヘッダーの高さに応じて調整 */
   right: 30px;
   z-index: 1000;
   cursor: pointer;
+  color: black;
 }
 
 .hidden {


### PR DESCRIPTION
…を実装する_#7

## GitHub Issue Ticket

- https://github.com/maixhashi/plotforge/issues/7

## やった事
 - フロントでの /users/1/shuffled_overviews/related_movies への導線を作成

### なぜやるのか

- https://github.com/maixhashi/plotforge/issues/7　参照


## 動作確認

development環境
1. http://localhost:3000/users/1/shuffled_overviews にアクセス
2. .link-to-related-movies をクリック
3. http://localhost:3000/users/1/shuffled_overviews/related_movies にアクセスできることを確認

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし