### PR TITLE
Bugfix 2024.08.04.15.35 groupdateの削除・my sqlクエリに書き換え #15

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ gem 'sassc-rails'
 gem 'httparty'
 gem 'dotenv-rails', groups: [:development, :test]
 gem 'simple_calendar'
-gem 'groupdate'
 gem 'rails-i18n'
 
 

--- a/app/controllers/related_movies_controller.rb
+++ b/app/controllers/related_movies_controller.rb
@@ -21,7 +21,6 @@ class RelatedMoviesController < ApplicationController
       .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
       .select("DATE(created_at) AS date, COUNT(movies.movie_id) AS movie_count")
       .where(user_id: current_user.id)
-      .where(created_at: @start_date.beginning_of_day..@start_date.end_of_day)
       .group("DATE(created_at)")
       .map { |record| [record.date, record.movie_count] }
       .to_h

--- a/app/views/users/shuffled_overviews/filter_shuffled_overviews_by_date.js.erb
+++ b/app/views/users/shuffled_overviews/filter_shuffled_overviews_by_date.js.erb
@@ -1,1 +1,1 @@
-document.querySelector('.shuffled-overview-list').innerHTML = "<%= j render partial: 'shuffled_overview_list', locals: { shuffled_movies: @shuffled_movies } %>";
+document.querySelector('.shuffled-overview-list').innerHTML = "<%= j render partial: 'shuffled_overview_list', locals: { shuffled_overviews: @shuffled_overviews } %>";


### PR DESCRIPTION
## GitHub Issue Ticket

- https://github.com/maixhashi/plotforge/issues/13
  - https://github.com/maixhashi/plotforge/issues/15

## やった事

`このプルリクエストにて何をしたのか？`
コントローラーで日付ソートしたレコードを抽出しようとするとき、
`gem 'groupdate'`により定義されている.group_by_dateで日付ソートした上で他の条件を
MySQLクエリで検索しようとするとエラーが起きるため、
`gem 'groupdate'`を削除し、MySQLクエリによるレコードフィルタに統一

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

MySQLのエラー回避
```shell
   ShuffledOverview Load (2.0ms)  SELECT `shuffled_overviews`.* FROM `shuffled_overviews` CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies WHERE (`shuffled_overviews`.`created_at` IS NOT NULL) GROUP BY CAST(DATE_FORMAT(CONVERT_TZ(`shuffled_overviews`.`created_at`, '+00:00', 'Asia/Tokyo'), '%Y-%m-%d') AS DATE)
web  |   ↳ app/controllers/related_movies_controller.rb:23:in `index'
web  | Completed 500 Internal Server Error in 880ms (ActiveRecord: 69.0ms | Allocations: 32544)
web  | 
web  | 
web  |   
web  | ActiveRecord::StatementInvalid (Mysql2::Error: Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'app_development.shuffled_overviews.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by):
``` 

## 動作確認

`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

development環境
1. http://localhost:3000/users/1/related_movies にアクセス
2. 映画の日付ソート用のカレンダーをクリック
3. カレンダーに日付ごとの映画の数が表示できている確認
4. 映画の数（.count）をクリックすることで日付ソート表示されることを確認する

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし