### PR TITLE
Feature_2024.08.04.16.01_映画一覧画面から映画詳細画面への導線リンクを追加する_#18

### DIFF
--- a/app/views/users/related_movies/_related_movie_list.html.erb
+++ b/app/views/users/related_movies/_related_movie_list.html.erb
@@ -1,7 +1,9 @@
 <div class="related-movie-images">
   <% @movies_data.each do |movie_id, movie| %>
     <div class="related-movie-image">
-      <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+        <%= link_to movie_path(movie_id) do %>
+            <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+        <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/users/shuffled_overviews/_shuffled_overview_list.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overview_list.html.erb
@@ -6,7 +6,9 @@
           <div class="movie-images">
             <% shuffled_overview.movie_ids.each do |movie_id| %>
               <% movie = @movies_data[movie_id] %>
-              <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+              <%= link_to movie_path(movie_id) do %>
+                <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+              <% end %>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## GitHub Issue Ticket

- https://github.com/maixhashi/plotforge/issues/18

## やった事

`このプルリクエストにて何をしたのか？`
映画一覧に表示される映画画像に映画詳細画面への導線リンクを追加。

### なぜやるのか

`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
映画が画像として表示されるだけでは不十分と考えた。

## 動作確認

`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

development環境
下記のリンクにアクセスし、表示されている映画の画像に映画詳細画面へのリンクが実装されていることを確認
 - http://localhost:3000/users/1/shuffled_overviews
   - http://localhost:3000/users/1/shuffled_overviews/filter_shuffled_overviews_by_date/2024-08-05
 - http://localhost:3000/users/1/related_movies
   - http://localhost:3000/users/1/related_movies/filter_movies_by_date/:date


## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし