### PR TITLE
Bug_2024.08.04.16.31_ヘッダーのハンバーガーボタンが有効にならない画面がある_#20

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -201,58 +201,6 @@ main {
 }
 
 /* ボタンを右寄せ */
-.hamburger-button {
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 10px;
-  position: absolute;
-  top: 10px;
-  right: 10px;
-}
-
-.hamburger-button i {
-  font-size: 24px; /* アイコンのサイズを調整 */
-}
-
-/* メニューを右側からスライドインする */
-.hamburger-menu {
-  position: fixed;
-  top: 0;
-  right: -100%;
-  width: 250px;
-  height: 100%;
-  background-color: #e0f7fa; /* 薄い明るい青 */
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
-  z-index: 1000;
-  display: flex;
-  flex-direction: column;
-  transition: right 0.3s ease-in-out;
-}
-
-.hamburger-menu ul {
-  list-style: none;
-  padding: 0;
-  margin: 50px 0 0; /* トップのマージンを追加してヘッダーと重ならないようにする */
-}
-
-.hamburger-menu li {
-  padding: 10px 20px;
-  border-bottom: 1px solid #ccc;
-}
-
-.hamburger-menu li a {
-  text-decoration: none;
-  color: #333;
-}
-
-.hamburger-menu li a:hover {
-  background-color: #f0f0f0;
-}
-
-.hamburger-menu.show {
-  right: 0;
-}
 
 .user-profile {
   display: flex;

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -53,22 +53,7 @@ document.addEventListener('DOMContentLoaded', () => {
     for (let i = 0; i < 10; i++) { // 5つの要素を生成する例
       createRandomTextElement(generateRandomPhrase(10)); // 10文字のランダムな文字列を生成
     }
-  });
-
-  document.addEventListener("DOMContentLoaded", function() {
-  const hamburgerButton = document.getElementById("hamburger-button");
-  const hamburgerMenu = document.getElementById("hamburger-menu");
-  const closeButton = document.getElementById("close-button");
-
-  if (hamburgerButton && hamburgerMenu) {
-    hamburgerButton.addEventListener("click", function() {
-      hamburgerMenu.classList.toggle("show");
-    });
-  }
-
-  if (closeButton) {
-    closeButton.addEventListener("click", function() {
-      hamburgerMenu.classList.remove("show");
-    });
-  }
+    
+  
+    
 });

--- a/app/views/layouts/_header_navibar.html.erb
+++ b/app/views/layouts/_header_navibar.html.erb
@@ -1,18 +1,106 @@
-<button id="hamburger-button" class="hamburger-button">
-    <i class="fas fa-bars"></i>
-</button>
-
-<nav id="hamburger-menu" class="hamburger-menu hidden">
-    <button id="close-button" class="close-button">
-    <i class="fas fa-times"></i>
+<div>
+    <button id="hamburger-button" class="hamburger-button">
+    <i class="fa fa-bars" aria-hidden="true"></i>
     </button>
 
-    <ul>
+    <nav id="hamburger-menu" class="hamburger-menu hidden">
+        <button id="close-button" class="close-button">
+        <i class="fa fa-times" aria-hidden="true"></i>
+        </button>
+
+        <ul>
         <li><%= link_to 'プロフィール', profile_path %></li>
         <li><%= link_to '設定', settings_path %></li>
         <li><%= link_to '作成したあらすじ', user_shuffled_overviews_path(current_user) %></li>
         <li><%= link_to 'お気に入り' %></li>
         <li><%= link_to 'ログアウト', logout_path, method: :delete %></li>
-    </ul>
-</nav>
+        </ul>
+    </nav>
+</div>
 
+<style>
+.close-button {
+    background-color: #e0f7fa;
+}
+
+.hamburger-menu {
+    position: fixed;
+    top: 0;
+    right: -100%;
+    width: 250px;
+    height: 100%;
+    background-color: #e0f7fa;
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+    display: none; /* 初期状態では非表示 */
+    transition: right 0.3s ease-in-out;
+}
+
+.hamburger-menu.show {
+    right: 0; /* showクラスが追加されたら表示位置を右に変更 */
+    display: block; /* これで表示されない場合、displayプロパティも追加 */
+}
+
+.hamburger-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 10px;
+}
+
+.hamburger-button i {
+  font-size: 24px; /* アイコンのサイズを調整 */
+}
+
+.hamburger-menu ul {
+  list-style: none;
+  padding: 0;
+  margin: 50px 0 0; /* トップのマージンを追加してヘッダーと重ならないようにする */
+}
+
+.hamburger-menu li {
+  padding: 10px 20px;
+  border-bottom: 1px solid #ccc;
+}
+
+.hamburger-menu li a {
+  text-decoration: none;
+  color: #333;
+}
+
+.hamburger-menu li a:hover {
+  background-color: #f0f0f0;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const hamburgerButton = document.getElementById("hamburger-button");
+    const hamburgerMenu = document.getElementById("hamburger-menu");
+    const closeButton = document.getElementById("close-button");
+
+    if (hamburgerButton && hamburgerMenu) {
+        console.log("Hamburger button and menu found."); // 確認用メッセージ
+
+        hamburgerButton.addEventListener("click", function() {
+            console.log("Hamburger button clicked!"); // 確認用メッセージ
+            hamburgerMenu.classList.toggle("show");
+            console.log(hamburgerMenu.classList.contains("show") ? "Menu is visible" : "Menu is hidden");
+            console.log(hamburgerMenu.classList); // クラスリストを確認
+        });
+    } else {
+        console.log("Hamburger button or menu not found."); // エラー時のメッセージ
+    }
+
+    if (closeButton) {
+        console.log("Close button found."); // 確認用メッセージ
+
+        closeButton.addEventListener("click", function() {
+            console.log("Close button clicked!"); // 確認用メッセージ
+            hamburgerMenu.classList.remove("show");
+        });
+    } else {
+        console.log("Close button not found."); // エラー時のメッセージ
+    }
+});   
+</script>


### PR DESCRIPTION
## GitHub Issue Ticket

- #20 

## やった事

`このプルリクエストにて何をしたのか？`
ハンバーガーボタンがホームページ（`root_parh`）以外で開けない不具合を修正

### なぜやるのか

`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
ハンバーガーボタンの本来の機能の修正

## 動作確認

`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
1. ホームページ http://localhost:3000/ 以外のページにアクセスし、
2. ハンバーガーボタンを開く
3. ナビバーが表示されることを確認

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
application.scssやapplication.jsで定義していたハンバーガーボタンのスタイル、jsを
ハンバーガーボタンのhtml内でまとめたことにより読み込めない不具合が解消した。