### PR TITLE
Style 2024.08.04.22.25 ウィンドウスクロールしてもヘッダー・フッターの位置は固定されているようにする #22

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,16 +20,18 @@ body {
 }
 
 header {
-  background: #e0f7fa; /* 薄い明るい青 */
-  color: #333; /* 文字色を暗い色に */
+  background: #e0f7fa;
+  color: #333;
   padding: 1rem;
   display: flex;
   align-items: center;
-  justify-content: space-between; /* 左右に要素を配置 */
-  position: relative; /* headerにrelativeを設定 */
-  z-index: 10; /* headerを前面に配置 */
-  height: var(--header-height); /* ヘッダーの高さ */
+  justify-content: space-between;
+  position: fixed;
+  z-index: 10;
+  height: var(--header-height);
   border: 3px solid #333;
+  top: 0;
+  width: 100%;
 }
 
 header img.logo_on_header {

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,3 +1,19 @@
 <footer>
   <p>&copy; <%= Time.current.year %> PlotForge. All rights reserved.</p>
 </footer>
+
+<style>
+footer {
+  position: fixed;
+  background: #e0f7fa;
+  color: #00796b;
+  padding: 1rem;
+  text-align: center;
+  margin-top: auto;
+  z-index: 100;
+  height: var(--footer-height);
+  border: 3px solid #333;
+  bottom: 0;
+  width: 100%;
+}
+</style>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,25 +2,25 @@
   <img src="<%= asset_path('logo_on_header.png') %>" alt="Logo" class="logo_on_header">
 <% end %>
 <div class="header-buttons">
-<% if current_user %>
-  <div class="header-link">
-    <%= link_to shuffled_overview_path, class:"header-link-of-shuffled-overview" do %>
-      <i class="fa fa-pencil fa-2x"></i>
-      <div>あらすじ</div>
-    <% end %>
-  </div>
-  <div class="user-info">
-    <% if current_user.avatar? %>
-        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
-    <% else %>
-        <i class="fa fa-user-circle fa-2x"></i>
-        <div class="user-name"><%= current_user.name %></div>
-    <% end %>
+  <% if current_user %>
+    <div class="header-link">
+      <%= link_to shuffled_overview_path, class:"header-link-of-shuffled-overview" do %>
+        <i class="fa fa-pencil fa-2x"></i>
+        <div>あらすじ</div>
+      <% end %>
     </div>
-      <%= render 'layouts/header_navibar' %>
-    <% else %>
-      <%= link_to 'ログイン', login_path, class: 'btn btn-login' %>
-      <%= link_to 'サインアップ', signup_path, class: 'btn btn-signup' %>
+    <div class="user-info">
+      <% if current_user.avatar? %>
+          <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+      <% else %>
+          <i class="fa fa-user-circle fa-2x"></i>
+          <div class="user-name"><%= current_user.name %></div>
+      <% end %>
+    </div>
+    <%= render 'layouts/header_navibar' %>
+  <% else %>
+        <%= link_to 'ログイン', login_path, class: 'btn btn-login' %>
+        <%= link_to 'サインアップ', signup_path, class: 'btn btn-signup' %>
   <% end %>
 </div>
 

--- a/app/views/layouts/_header_navibar.html.erb
+++ b/app/views/layouts/_header_navibar.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="hamburger-button-on-header">
     <button id="hamburger-button" class="hamburger-button">
     <i class="fa fa-bars" aria-hidden="true"></i>
     </button>
@@ -19,6 +19,10 @@
 </div>
 
 <style>
+.hamburger-button-on-header{
+
+}
+
 .close-button {
     background-color: #e0f7fa;
 }
@@ -46,6 +50,7 @@
   border: none;
   cursor: pointer;
   padding: 10px;
+  margin-right: 20px;
 }
 
 .hamburger-button i {

--- a/app/views/users/related_movies/index.html.erb
+++ b/app/views/users/related_movies/index.html.erb
@@ -23,14 +23,14 @@
 }
 
 .related-movie-images {
-  margin-top: 10px;
-  margin-bottom: 10px;
+  margin-top: 100px;
+  margin-bottom: 100px;
   margin-left: 10px;
   margin-right: 10px;
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-  justify-content: start /* 中央揃え */
+  justify-content: start /* 中央揃え */;
 }
 
 .related-movie-image {

--- a/app/views/users/shuffled_overviews/index.html.erb
+++ b/app/views/users/shuffled_overviews/index.html.erb
@@ -48,7 +48,9 @@
   display: flex;
   flex-flow: column;
   flex-wrap: nowrap;
-  align-items: center; /* 中央に配置 */
+  align-items: center;
+  margin-top: 100px;
+  margin-bottom: 100px;
 
   .shuffled-overview-item {
     margin-bottom: 20px;
@@ -56,7 +58,7 @@
     border: 1px solid #ddd;
     border-radius: 5px;
     background-color: #f9f9f9;
-    width: 80%; /* 横幅を調整 */
+    width: 100%; /* 横幅を調整 */
     box-sizing: border-box;
 
     .shuffled-overview-content {


### PR DESCRIPTION
## GitHub Issue Ticket

- #22 

## やった事

`このプルリクエストにて何をしたのか？`
 - `position: fixed;` によりヘッダー・フッターの位置を固定
 - 映画の画像がヘッダーに隠れないように .related-imagesの margin-top, margin-bottom を調整
 - ハンバーガーボタンが画面外に隠れたため位置を margin-right で調整

### なぜやるのか

`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
映画の画像データが増えたときにヘッダーの機能ボタン（ハンバーガーボタン）などを
画面最上部まで戻って押さなければならないというようなケースをなくすための実装


## 動作確認

`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
development環境
1. http://localhost:3000/users/1/shuffled_overviews
2. http://localhost:3000/users/1/related_movies
にアクセスし、ヘッダー・フッターの位置が固定されていることを確認

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
