### PR TITLE
Feature 2024.08.11.22.16 ブックマークしたshuffled overviewモデルレコードを表示・作成日ソートする機能を実装する #36

### DIFF
--- a/app/controllers/bookmark_of_shuffled_overviews_controller.rb
+++ b/app/controllers/bookmark_of_shuffled_overviews_controller.rb
@@ -3,31 +3,42 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
   def index
     @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
 
+    @grouped_bookmark_for_count = BookmarkOfShuffledOverview
+    .where(user_id: current_user.id)
+    .select("DATE(created_at) AS date, COUNT(*) AS count")
+    .group("DATE(created_at)")
+    .map { |record| [record.date.to_date, record.count] }
+    .to_h
+
+    @grouped_bookmark_for_count.inspect
+
     @shuffled_overviews = current_user.shuffled_overviews
 
     # 映画データを取得する
     tmdb_service = TmdbService.new
     @movies_data = {}
-    @shuffled_overviews.each do |shuffled_overview|
-      shuffled_overview.movie_ids.each do |movie_id|
-        @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
-      end
-    end
+    date_param = params[:date].presence || Date.today.to_s
 
-    # MySQL で日付ごとにカウントを取得
+    begin
+      date = date_param.to_date
+    rescue ArgumentError
+      date = Date.today
+    end
+    
+    @date_range = date.beginning_of_day..date.end_of_day
+
     @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
-    .select('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+    .where(bookmark_of_shuffled_overviews: { created_at: @date_range })
+    .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
     .joins(:bookmark_of_shuffled_overviews)
-    .group('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at)')
+    .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
     .each_with_object({}) do |overview, hash|
       date = overview.date
       hash[date] ||= []
       hash[date] << overview
     end
 
-    date_key = @grouped_bookmarked_shuffled_overviews.keys.first
-    Rails.logger.debug "ShuffledOverview movie_ids: #{@grouped_bookmarked_overviews.inspect}"
-                               
+    @grouped_bookmarked_shuffled_overviews.inspect
 
     render 'users/bookmark_of_shuffled_overviews/index'
   end
@@ -55,15 +66,25 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
   end
   
   def filter_bookmarked_overviews_by_date
+    @grouped_bookmark_for_count = BookmarkOfShuffledOverview
+    .where(user_id: current_user.id)
+    .select("DATE(created_at) AS date, COUNT(*) AS count")
+    .group("DATE(created_at)")
+    .map { |record| [record.date.to_date, record.count] }
+    .to_h
+
+    @grouped_bookmark_for_count.inspect
+
     # 日付パラメータが存在しない場合は Date.today を使用
-    date_param = params[:date].presence || Date.today.to_s
+    Time.zone = 'UTC'
+    date_param = params[:date].presence || Date.current.to_s
     
     begin
       date = date_param.to_date
     rescue ArgumentError
-      date = Date.today
+      date = Date.current
     end
-    
+
     @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
     
     # 指定された日付範囲のデータを取得
@@ -72,23 +93,29 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
     # 映画データを再取得する
     tmdb_service = TmdbService.new
     @movies_data = {}
-    @shuffled_overviews.each do |shuffled_overview|
-      shuffled_overview.movie_ids.each do |movie_id|
+    @bookmarked_shuffled_overviews.each do |bookmarked_shuffled_overview|
+      bookmarked_shuffled_overview.movie_ids.each do |movie_id|
         @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
       end
     end
     
-    # MySQL で日付ごとにカウントを取得
+    @movies_data.inspect
+    @movies_data['poster_path'].inspect
+    
+    @date_range = date.beginning_of_day..date.end_of_day
+
     @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
-    .where(created_at: date.all_day)
-    .select('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+    .where(bookmark_of_shuffled_overviews: { created_at: @date_range })
+    .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
     .joins(:bookmark_of_shuffled_overviews)
-    .group('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at)')
+    .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
     .each_with_object({}) do |overview, hash|
       date = overview.date
       hash[date] ||= []
       hash[date] << overview
     end
+
+    @grouped_bookmarked_shuffled_overviews.inspect
     
     respond_to do |format|
       format.html { render 'users/bookmark_of_shuffled_overviews/index' }

--- a/app/controllers/bookmark_of_shuffled_overviews_controller.rb
+++ b/app/controllers/bookmark_of_shuffled_overviews_controller.rb
@@ -1,6 +1,37 @@
 class BookmarkOfShuffledOverviewsController < ApplicationController
   # before_action :authenticate_user!
+  def index
+    @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
 
+    @shuffled_overviews = current_user.shuffled_overviews
+
+    # 映画データを取得する
+    tmdb_service = TmdbService.new
+    @movies_data = {}
+    @shuffled_overviews.each do |shuffled_overview|
+      shuffled_overview.movie_ids.each do |movie_id|
+        @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
+      end
+    end
+
+    # MySQL で日付ごとにカウントを取得
+    @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
+    .select('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+    .joins(:bookmark_of_shuffled_overviews)
+    .group('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at)')
+    .each_with_object({}) do |overview, hash|
+      date = overview.date
+      hash[date] ||= []
+      hash[date] << overview
+    end
+
+    date_key = @grouped_bookmarked_shuffled_overviews.keys.first
+    Rails.logger.debug "ShuffledOverview movie_ids: #{@grouped_bookmarked_overviews.inspect}"
+                               
+
+    render 'users/bookmark_of_shuffled_overviews/index'
+  end
+  
   def create
     @shuffled_overview = ShuffledOverview.find(params[:shuffled_overview_id])
     current_user.bookmarked_shuffled_overviews << @shuffled_overview
@@ -22,4 +53,48 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
       format.js   # create.js.erb を呼び出します
     end
   end
+  
+  def filter_bookmarked_overviews_by_date
+    # 日付パラメータが存在しない場合は Date.today を使用
+    date_param = params[:date].presence || Date.today.to_s
+    
+    begin
+      date = date_param.to_date
+    rescue ArgumentError
+      date = Date.today
+    end
+    
+    @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
+    
+    # 指定された日付範囲のデータを取得
+    @shuffled_overviews = ShuffledOverview.where(created_at: date.all_day)
+    
+    # 映画データを再取得する
+    tmdb_service = TmdbService.new
+    @movies_data = {}
+    @shuffled_overviews.each do |shuffled_overview|
+      shuffled_overview.movie_ids.each do |movie_id|
+        @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
+      end
+    end
+    
+    # MySQL で日付ごとにカウントを取得
+    @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
+    .where(created_at: date.all_day)
+    .select('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+    .joins(:bookmark_of_shuffled_overviews)
+    .group('shuffled_overviews.id, shuffled_overviews.content, DATE(bookmark_of_shuffled_overviews.created_at)')
+    .each_with_object({}) do |overview, hash|
+      date = overview.date
+      hash[date] ||= []
+      hash[date] << overview
+    end
+    
+    respond_to do |format|
+      format.html { render 'users/bookmark_of_shuffled_overviews/index' }
+      format.js   { render :filter_bookmarked_overviews_by_date }
+    end
+  end
+  
+  
 end

--- a/app/views/bookmark_of_shuffled_overviews/filter_bookmarked_overviews_by_date.js.erb
+++ b/app/views/bookmark_of_shuffled_overviews/filter_bookmarked_overviews_by_date.js.erb
@@ -1,0 +1,1 @@
+document.querySelector('.bookmarked-shuffled-overview-list').innerHTML = "<%= j render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { shuffled_overviews: @shuffled_overviews } %>";

--- a/app/views/bookmark_of_shuffled_overviews/filter_bookmarked_overviews_by_date.js.erb
+++ b/app/views/bookmark_of_shuffled_overviews/filter_bookmarked_overviews_by_date.js.erb
@@ -1,1 +1,1 @@
-document.querySelector('.bookmarked-shuffled-overview-list').innerHTML = "<%= j render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { shuffled_overviews: @shuffled_overviews } %>";
+document.querySelector('.bookmarked-shuffled-overview-list').innerHTML = "<%= j render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { grouped_bookmarked_shuffled_overviews: @grouped_bookmarked_shuffled_overviews } %>";

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_overviews_count_calendar.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_overviews_count_calendar.html.erb
@@ -3,9 +3,9 @@
     <%= month_calendar do |date| %>
       <div class="calendar-day">
         <%= date.day %>
-         <% if @grouped_bookmarked_shuffled_overviews[date] %>
+         <% if @grouped_bookmark_for_count[date] %>
             <%= link_to filter_bookmarked_overviews_by_date_user_bookmark_of_shuffled_overviews_path(date: date), remote: true, class: "count" do %>
-                <div><%= @grouped_bookmarked_shuffled_overviews.keys.count %></div>
+                <div><%= @grouped_bookmark_for_count[date] %></div>
             <% end %>
         <% end %>
       </div>
@@ -75,8 +75,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   const calendarContainer = document.querySelector('#bookmarked_shuffled_overviews_count_calendar');
 
-  console.log('find #bookmarked_shuffled_overviews_count_calendar')
-  
   document.addEventListener('click', function(event) {
     const target = event.target.closest('.previous, .next, .today, .start-date');
     if (target) {

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_overviews_count_calendar.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_overviews_count_calendar.html.erb
@@ -1,0 +1,178 @@
+<div class="fixed-calendar hidden" id="bookmarked_shuffled_overviews_count_calendar">
+  <div class="calendar-container">
+    <%= month_calendar do |date| %>
+      <div class="calendar-day">
+        <%= date.day %>
+         <% if @grouped_bookmarked_shuffled_overviews[date] %>
+            <%= link_to filter_bookmarked_overviews_by_date_user_bookmark_of_shuffled_overviews_path(date: date), remote: true, class: "count" do %>
+                <div><%= @grouped_bookmarked_shuffled_overviews.keys.count %></div>
+            <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<style>
+.fixed-calendar.visible {
+  display: flex; /* 表示時にフレックスに変更 */
+}
+
+.hidden {
+  display: none;
+}
+
+
+.calendar-container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  max-width: 1100px; /* カレンダーの最大幅を設定 */
+  align-items: center;
+}
+
+
+.fixed-calendar {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80%;
+  background-color: rgba(255, 255, 255, 0.9);
+  z-index: 900;
+  padding: 10px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: none; /* 初期状態で非表示 */
+  flex-direction: column;
+  align-items: center;
+}
+
+.content {
+    padding: 20px;
+}
+
+.calendar-day {
+    position: relative;
+}
+
+.count {
+  width: 40px;
+  height: 40px;
+  background-color: #007bff;
+  opacity: 70%;
+  color: white;
+  border-radius: 50%;
+  text-align:center;
+  line-height: 40px;
+  position:absolute;
+  top: 100%;
+  left: 30%;
+  text-decoration: none;
+}
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const calendarContainer = document.querySelector('#bookmarked_shuffled_overviews_count_calendar');
+
+  console.log('find #bookmarked_shuffled_overviews_count_calendar')
+  
+  document.addEventListener('click', function(event) {
+    const target = event.target.closest('.previous, .next, .today, .start-date');
+    if (target) {
+      event.preventDefault();
+      const url = target.href;
+
+      fetch(url, {
+        headers: {
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
+      .then(response => response.text())
+      .then(html => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const newCalendar = doc.querySelector('#bookmarked_shuffled_overviews_count_calendar').innerHTML;
+        calendarContainer.innerHTML = newCalendar;
+        registerNavigationEvents();  // 必要な場合にイベントハンドラを再登録
+      });
+    }
+  });
+
+  function registerNavigationEvents() {
+    // ナビゲーションリンクのイベントハンドラを再登録
+    document.querySelectorAll('.previous, .next, .today, .start-date').forEach(link => {
+      link.addEventListener('click', event => {
+        event.preventDefault();
+        const url = event.target.href;
+
+        fetch(url, {
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest'
+          }
+        })
+        .then(response => response.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          const newCalendar = doc.querySelector('#bookmarked_shuffled_overviews_count_calendar').innerHTML;
+          calendarContainer.innerHTML = newCalendar;
+          registerNavigationEvents();  // 必要な場合にイベントハンドラを再登録
+        });
+      });
+    });
+  }
+
+    function getFormattedDate(date) {
+      const year = date.getFullYear();
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    }
+  
+    // 現在の日付を取得
+    const todayDate = new Date();
+    const formattedDate = getFormattedDate(todayDate);
+  
+    function registerNavigationEvents() {
+      document.querySelectorAll('.start-date').forEach(link => {
+        link.addEventListener('click', event => {
+          event.preventDefault();
+          const baseUrl = event.target.closest('a').href;
+          // URLのパスが"/filter_shuffled_overviews_by_date" で終わる場合に追加する
+          // const url = `${baseUrl.replace(/\/filter_shuffled_overviews_by_date\/.*$/, '')}/filter_shuffled_overviews_by_date/${formattedDate}`;
+  
+          fetch(url, {
+            headers: {
+              'X-Requested-With': 'XMLHttpRequest'
+            }
+          })
+          .then(response => response.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const newCalendar = doc.querySelector('#bookmarked_shuffled_overviews_count_calendar').innerHTML;
+            calendarContainer.innerHTML = newCalendar;
+  
+            // URLを更新
+            window.history.pushState({}, '', url);
+            window.location.reload();
+  
+            // Debug: check if shuffled-overview-list exists
+            const shuffledOverviewList = doc.querySelector('.bookmarked-shuffled-overview-list');
+            if (shuffledOverviewList) {
+              document.querySelector('.bookmarked-shuffled-overview-list').innerHTML = shuffledOverviewList.innerHTML;
+            } else {
+              console.error('Shuffled overview list element not found.');
+            }
+            registerNavigationEvents();
+          })
+          .catch(error => console.error('Error:', error));
+        });
+      });
+    }
+  
+    registerNavigationEvents();
+  });
+  
+</script>

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
@@ -1,0 +1,97 @@
+<div class="content">
+  <% if @grouped_bookmarked_shuffled_overviews.present? %>
+    <div class="bookmarked-shuffled-overview-list">
+      <% @bookmarked_shuffled_overviews.each do |bookmarked_shuffled_overview| %>
+        <div class="shuffled-overview-item">
+          <div class="movie-images-container">
+            <div class="movie-images">
+              <% bookmarked_shuffled_overview.movie_ids.each do |movie_id| %>
+                <% movie = @movies_data[movie_id] %>
+                <%= link_to movie_path(movie_id) do %>
+                  <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+          <div class="shuffled-overview-content">
+            <%= bookmarked_shuffled_overview.content.html_safe %>
+            <div class="shuffled-overview-meta">
+              <p>保存日時: <%= bookmarked_shuffled_overview.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+            </div>
+            <div class="button-container">
+              <button class="read-aloud-button btn btn-login">
+                <i class="fas fa-volume-up"></i> 読み上げ
+              </button>
+              <button class="stop-button btn btn-login">
+                停止
+              </button>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p>指定された日付にはブックマークされたシャッフル概要がありません。</p>
+  <% end %>
+</div>
+
+<style>
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* 中央に配置 */
+}
+
+.shuffled-overview-list {
+  display: flex;
+  flex-direction: column; /* 縦並びにする */
+  width: 80%; /* 横幅を調整 */
+  box-sizing: border-box;
+}
+
+.shuffled-overview-item {
+  display: flex; /* 横並びにする */
+  align-items: flex-start; /* 上揃え */
+  margin-bottom: 20px;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+  width: 100%; /* 横幅を100%にして、親コンテナ内での幅を調整 */
+  box-sizing: border-box;
+}
+
+.movie-images-container {
+  display: flex;
+  flex-direction: column; /* 画像を縦に並べる */
+  margin-right: 20px; /* あらすじとの間隔を調整 */
+}
+
+.movie-images {
+  display: flex; /* 画像を横並びにする */
+  flex-direction: column; /* 画像を縦に並べる */
+  gap: 10px; /* 画像間の間隔 */
+}
+
+.movie-images img {
+  max-width: 100px; /* 画像の幅を制限 */
+  max-height: 150px; /* 画像の高さを制限 */
+  object-fit: cover; /* 画像が領域に収まるように調整 */
+}
+
+.shuffled-overview-content {
+  font-size: 16px;
+  margin-bottom: 10px;
+  flex: 1; /* コンテンツが残りのスペースを占めるようにする */
+}
+
+.shuffled-overview-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.button-container {
+  text-align: center;
+}
+
+</style>

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
@@ -1,39 +1,45 @@
 <div class="content">
-  <% if @grouped_bookmarked_shuffled_overviews.present? %>
-    <div class="bookmarked-shuffled-overview-list">
-      <% @bookmarked_shuffled_overviews.each do |bookmarked_shuffled_overview| %>
-        <div class="shuffled-overview-item">
-          <div class="movie-images-container">
-            <div class="movie-images">
-              <% bookmarked_shuffled_overview.movie_ids.each do |movie_id| %>
-                <% movie = @movies_data[movie_id] %>
-                <%= link_to movie_path(movie_id) do %>
-                  <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+  <div class="bookmarked-shuffled-overview-list">
+    <% if @grouped_bookmarked_shuffled_overviews.present? %>
+      <% @grouped_bookmarked_shuffled_overviews.each do |date, overviews| %>
+        <% overviews.each do |bookmarked_shuffled_overview| %>
+          <div class="shuffled-overview-item">
+            <div class="movie-images-container">
+              <div class="movie-images">
+                <% bookmarked_shuffled_overview.movie_ids.each do |movie_id| %>
+                  <% movie = @movies_data[movie_id] %>
+                  <% if movie && movie['poster_path'] %>
+                    <%= link_to movie_path(movie_id) do %>
+                      <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+                    <% end %>
+                  <% end %>
                 <% end %>
-              <% end %>
+              </div>
+            </div>
+            <div class="shuffled-overview-content">
+              <%= bookmarked_shuffled_overview.content.html_safe %>
+              <div class="shuffled-overview-meta">
+                <% bookmark = BookmarkOfShuffledOverview.where(user_id: current_user.id, shuffled_overview_id: bookmarked_shuffled_overview.id).first %>
+                <p>お気に入りに追加した日時: <%= bookmark.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+              </div>
+              <div class="button-container">
+                <button class="read-aloud-button btn btn-login">
+                  <i class="fas fa-volume-up"></i> 読み上げ
+                </button>
+                <button class="stop-button btn btn-login">
+                  停止
+                </button>
+              </div>
             </div>
           </div>
-          <div class="shuffled-overview-content">
-            <%= bookmarked_shuffled_overview.content.html_safe %>
-            <div class="shuffled-overview-meta">
-              <p>保存日時: <%= bookmarked_shuffled_overview.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
-            </div>
-            <div class="button-container">
-              <button class="read-aloud-button btn btn-login">
-                <i class="fas fa-volume-up"></i> 読み上げ
-              </button>
-              <button class="stop-button btn btn-login">
-                停止
-              </button>
-            </div>
-          </div>
-        </div>
+        <% end %>
       <% end %>
-    </div>
-  <% else %>
+    <% else %>
+  </div>
     <p>指定された日付にはブックマークされたシャッフル概要がありません。</p>
   <% end %>
 </div>
+
 
 <style>
 .content {

--- a/app/views/users/bookmark_of_shuffled_overviews/index.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/index.html.erb
@@ -1,0 +1,202 @@
+<div>
+  <%= render 'users/bookmark_of_shuffled_overviews/bookmarked_overviews_count_calendar' %>
+</div>
+
+<div>
+  <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { bookmarked_shuffled_overviews: @bookmarked_shuffled_overviews } %>
+</div>
+
+
+<div id="movie-info-popup" class="hidden">
+  <div id="popup-title"></div>
+  <img id="popup-image" src="" alt="Movie Image">
+</div>
+
+<div class="link-icon-container">
+ <div class="calendar-toggle" id="calendar-icon-for-filtering-bookmarked-shuffled-overviews">
+   <i class="fa fa-3x fa-calendar"></i>
+ </div>
+ <div>
+   <%= link_to user_related_movies_path, class:"link-to-related-movies" do %>
+     <i class="fa fa-3x fa-film"></i>
+   <% end %>
+ </div>
+</div>
+
+
+<style>
+.calendar-toggle {
+  position: fixed;
+  bottom: 140px; /* ヘッダーの高さに応じて調整 */
+  right: 30px;
+  z-index: 1000;
+  cursor: pointer;
+}
+.link-to-related-movies {
+  position: fixed;
+  bottom: 70px; /* ヘッダーの高さに応じて調整 */
+  right: 30px;
+  z-index: 1000;
+  cursor: pointer;
+  color: black;
+}
+
+.hidden {
+  display: none;
+}
+
+.shuffled-overview-list {
+  display: flex;
+  flex-flow: column;
+  flex-wrap: nowrap;
+  align-items: center;
+  margin-top: 100px;
+  margin-bottom: 100px;
+
+  .shuffled-overview-item {
+    margin-bottom: 20px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background-color: #f9f9f9;
+    width: 100%; /* 横幅を調整 */
+    box-sizing: border-box;
+
+    .shuffled-overview-content {
+      font-size: 16px;
+      margin-bottom: 10px;
+    }
+  }
+}
+
+.shuffled-overview-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.movie-link {
+    text-decoration: none;
+    color: black;
+}
+
+.button-container {
+  text-align: center;
+}
+
+#movie-info-popup {
+  position: absolute;
+  display: none;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+  z-index: 1000;
+  max-width: 300px;
+  max-height: 200px;
+  overflow: hidden;
+}
+
+#popup-image {
+  max-width: 100%;
+  max-height: 150px;
+  display: block;
+}
+
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const popup = document.getElementById('movie-info-popup');
+  const popupTitle = document.getElementById('popup-title');
+  const popupImage = document.getElementById('popup-image');
+  const calendarIcon = document.getElementById('calendar-icon-for-filtering-bookmarked-shuffled-overviews');
+  const calendarContainer = document.getElementById('bookmarked_shuffled_overviews_count_calendar');
+
+  calendarIcon.addEventListener('click', () => {
+     calendarContainer.classList.toggle('visible');
+     // カレンダーが表示されたら内容を調整してマージントップを変更
+   });
+
+  function enableLinksAndHoverEvents() {
+    document.querySelectorAll('.movie-link').forEach(link => {
+      link.addEventListener('mouseover', (event) => {
+        const movieInfo = event.target.dataset.movieInfo;
+        const movieImage = event.target.dataset.movieImage;
+        popupTitle.textContent = movieInfo;
+        popupImage.src = movieImage;
+
+        popup.style.display = 'block';
+
+        let top = event.clientY + window.scrollY + 10;
+        let left = event.clientX + window.scrollX + 10;
+
+        const popupWidth = popup.offsetWidth;
+        const popupHeight = popup.offsetHeight;
+
+        if (left + popupWidth > window.innerWidth + window.scrollX) {
+          left = window.innerWidth + window.scrollX - popupWidth - 10;
+        }
+
+        if (top + popupHeight > window.innerHeight + window.scrollY) {
+          top = window.innerHeight + window.scrollY - popupHeight - 10;
+        }
+
+        popup.style.top = `${top}px`;
+        popup.style.left = `${left}px`;
+      });
+
+      link.addEventListener('mouseout', () => {
+        popup.style.display = 'none';
+      });
+    });
+  }
+
+  enableLinksAndHoverEvents();
+
+  document.querySelectorAll('.read-aloud-button').forEach(button => {
+    button.addEventListener('click', (event) => {
+      const container = event.target.closest('.shuffled-overview-item').querySelector('.shuffled-overview-content');
+      readAloud(container.textContent);
+    });
+  });
+
+  document.querySelectorAll('.stop-button').forEach(button => {
+    button.addEventListener('click', stopReading);
+  });
+
+  async function getVoices() {
+    return new Promise(resolve => {
+      let synth = window.speechSynthesis;
+      let id;
+
+      id = setInterval(() => {
+        if (synth.getVoices().length !== 0) {
+          resolve(synth.getVoices());
+          clearInterval(id);
+        }
+      }, 10);
+    });
+  }
+
+  let voices = [];
+
+  async function readAloud(text) {
+    if (voices.length === 0) {
+      voices = await getVoices();
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'ja-JP';
+
+    const voiceName = 'Kyoko';
+    const voice = voices.find(v => v.name.includes(voiceName)) || voices[0];
+    utterance.voice = voice;
+
+    speechSynthesis.speak(utterance);
+  }
+
+  function stopReading() {
+    speechSynthesis.cancel();
+  }
+});
+
+</script>

--- a/app/views/users/bookmark_of_shuffled_overviews/index.js.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/index.js.erb
@@ -1,0 +1,1 @@
+document.querySelector('#bookmarked_shuffled_overviews_count_calendar').innerHTML = "<%= j render partial: 'users/shuffled_overviews/bookmarked_overviews_count_calendar', locals: {start_date: @start_date, date_range: (start_date.beginning_of_month..start_date.end_of_month).to_a} %>";

--- a/app/views/users/bookmark_of_shuffled_overviews/index.js.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/index.js.erb
@@ -1,1 +1,1 @@
-document.querySelector('#bookmarked_shuffled_overviews_count_calendar').innerHTML = "<%= j render partial: 'users/shuffled_overviews/bookmarked_overviews_count_calendar', locals: {start_date: @start_date, date_range: (start_date.beginning_of_month..start_date.end_of_month).to_a} %>";
+document.querySelector('.bookmarked-shuffled-overview-list').innerHTML = "<%= j render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { grouped_bookmarked_shuffled_overviews: @grouped_bookmarked_shuffled_overviews } %>";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,11 @@ Rails.application.routes.draw do
       # delete 'bookmarks/:id', to: 'bookmark_of_shuffled_overviews#destroy', as: :bookmark
       delete 'bookmarks', to: 'bookmark_of_shuffled_overviews#destroy', as: :bookmark
     end
+    resources :bookmark_of_shuffled_overviews, only: [:index] do
+      collection do
+        get 'filter_bookmarked_overviews_by_date/:date', action: :filter_bookmarked_overviews_by_date, as: :filter_bookmarked_overviews_by_date
+      end
+    end
     resources :shuffled_overviews, only: [:index, :create] do
       collection do
         get 'filter_shuffled_overviews_by_date/:date', action: :filter_shuffled_overviews_by_date, as: :filter_shuffled_overviews_by_date


### PR DESCRIPTION
…能を実装する_#36

## GitHub Issue Ticket

- close #36 
  - close #33
  - close #38 

## やった事

`このプルリクエストにて何をしたのか？`
 - ブックマークしたShuffledOverviewモデルレコードの一覧表示
 - ブックマークしたShuffledOverviewモデルレコードの作成日ソート表示

### なぜやるのか

`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
基本的機能

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
development環境
1. http://localhost:3000/users/1/bookmark_of_shuffled_overviews にアクセス
2. 作成日ソート用のカレンダーをクリック
3. 日付をクリックして、クリックした該当日に作成されたBookmarkOfShuffleOverviewモデルレコードが表示されていることを確認する

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
