### PR TITLE
Feature_2024.08.12.13.28_作成日ソート機能を非同期処理する（ShuffledOverviewモデルレコードのソート…

### DIFF
--- a/app/controllers/shuffled_overviews_controller.rb
+++ b/app/controllers/shuffled_overviews_controller.rb
@@ -21,6 +21,8 @@ class ShuffledOverviewsController < ApplicationController
                                      .map { |record| [record.date.to_date, record.count] }
                                      .to_h
 
+    @grouped_overviews.inspect
+
     render 'users/shuffled_overviews/index'
     
     respond_to do |format|
@@ -84,7 +86,7 @@ class ShuffledOverviewsController < ApplicationController
     
     respond_to do |format|
       format.html { render 'users/shuffled_overviews/index' }
-      format.js   { render :filter_shuffled_overviews_by_date }
+      format.js   { render 'users/shuffled_overviews/filter_shuffled_overviews_by_date' }
     end
   end
   

--- a/app/views/users/shuffled_overviews/filter_shuffled_overviews_by_date.js.erb
+++ b/app/views/users/shuffled_overviews/filter_shuffled_overviews_by_date.js.erb
@@ -1,1 +1,1 @@
-document.querySelector('.shuffled-overview-list').innerHTML = "<%= j render partial: 'shuffled_overview_list', locals: { shuffled_overviews: @shuffled_overviews } %>";
+document.querySelector('.shuffled-overview-list').innerHTML = "<%= j render partial: 'users/shuffled_overviews/shuffled_overview_list', locals: { shuffled_overviews: @shuffled_overviews } %>";


### PR DESCRIPTION
…）_#37

## GitHub Issue Ticket

- close #37 

## やった事

`このプルリクエストにて何をしたのか？`
ShuffledOverviewモデルレコードの作成日ソート機能を非同期処理化
 - app/views/users/shuffled_overviews/filter_shuffled_overviews_by_date.js.erb の読み込みがされるように実装
### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
基本的機能

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
development環境
1. http://localhost:3000/users/1/shuffled_overviews にアクセス
2. 作成日ソート用カレンダーの日付をクリック
3. 非同期的に、指定した作成日のShuffledOverviewモデルレコードが現れることを確認

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし