### PR TITLE
Feature_2024.08.12.13.34_作成日ソート機能を非同期処理する（RelatedMovieモデルレコードのソート）_#39

### DIFF
--- a/app/controllers/related_movies_controller.rb
+++ b/app/controllers/related_movies_controller.rb
@@ -88,7 +88,7 @@ class RelatedMoviesController < ApplicationController
   
     respond_to do |format|
       format.html { render 'users/related_movies/index' }
-      format.js   { render :filter_movies_by_date }
+      format.js   { render 'users/shuffled_overviews/filter_movies_by_date' }
     end
   end
       

--- a/app/views/users/shuffled_overviews/filter_movies_by_date.js.erb
+++ b/app/views/users/shuffled_overviews/filter_movies_by_date.js.erb
@@ -1,1 +1,1 @@
-document.querySelector('.related-movie-images').innerHTML = "<%= j render partial: 'shuffled_overview_list', locals: { shuffled_movies: @shuffled_movies } %>";
+document.querySelector('.related-movie-images').innerHTML = "<%= j render partial: 'users/related_movies/related_movie_list', locals: { movies_data: @movies_data } %>";


### PR DESCRIPTION
## GitHub Issue Ticket

- close #39
- close #34 

## やった事
`このプルリクエストにて何をしたのか？`
RelatedMovieモデルレコードの非同期処理の実装
 - app/views/users/shuffled_overviews/filter_movies_by_date.js.erb が読み込まれるように実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
基本的機能

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
development環境
1. http://localhost:3000/users/1/related_movies にアクセス
2. 作成日ソート用のカレンダーの日付をクリック
3. 非同期的に指定した作成日の映画画像が表示されることを確認する

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし