### PR TITLE
Debug_2024.08.12.23.54_@grouped_overviews_with_movie_countsを修正_#35

### DIFF
--- a/app/controllers/related_movies_controller.rb
+++ b/app/controllers/related_movies_controller.rb
@@ -18,13 +18,12 @@ class RelatedMoviesController < ApplicationController
   
     # MySQL クエリで日付ごとの映画カウントを取得
     @grouped_overviews_with_movie_counts = ShuffledOverview
-      .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
-      .select("DATE(created_at) AS date, COUNT(movies.movie_id) AS movie_count")
-      .where(user_id: current_user.id)
-      .group("DATE(created_at)")
-      .map { |record| [record.date, record.movie_count] }
-      .to_h
-  
+    .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
+    .select("DATE(created_at) AS date, COUNT(DISTINCT movies.movie_id) AS movie_count")
+    .group("DATE(created_at)")
+    .map { |record| [record.date, record.movie_count] }
+    .to_h
+    
     render 'users/related_movies/index'
   
     respond_to do |format|
@@ -68,12 +67,14 @@ class RelatedMoviesController < ApplicationController
   
     # MySQL クエリで日付ごとの映画カウントを取得
     @grouped_overviews_with_movie_counts = ShuffledOverview
-      .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
-      .select("DATE(created_at) AS date, COUNT(movies.movie_id) AS movie_count")
-      .group("DATE(created_at)")
-      .map { |record| [record.date, record.movie_count] }
-      .to_h
+    .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
+    .select("DATE(created_at) AS date, COUNT(DISTINCT movies.movie_id) AS movie_count")
+    .group("DATE(created_at)")
+    .map { |record| [record.date, record.movie_count] }
+    .to_h
   
+    @grouped_overviews_with_movie_counts.inspect
+    
     # 映画データを再取得する
     tmdb_service = TmdbService.new
     @movies_data = {}
@@ -84,7 +85,6 @@ class RelatedMoviesController < ApplicationController
       end
     end
   
-    puts @grouped_overviews_with_movie_counts.inspect 
   
     respond_to do |format|
       format.html { render 'users/related_movies/index' }


### PR DESCRIPTION
## GitHub Issue Ticket

- close #35 

## やった事

`このプルリクエストにて何をしたのか？`
http://localhost:3000/users/1/related_movies の作成日ソート用のカレンダーの動画数を実態に合うように修正

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
作成日ソート用のカレンダーの動画数に対応する `@grouped_overviews_with_movie_counts` 

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
development環境
1. http://localhost:3000/users/1/related_movies にアクセス
2. 作成日ソート用のカレンダーをひらく
3. 作成日ごとに表示される映画画像数と、カレンダーに表示される映画画像数が一致していることを確認 
![image](https://github.com/user-attachments/assets/3f621400-7c57-4280-8103-9d52c68cbb04)

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
MySQLのクエリの`DISTINCT` を使用し重複カウントを排除