### PR TITLE
Feature_2024.08.13.03.28_@grouped_bookmarked_shuffled_overviewsの条件分岐を…

### DIFF
--- a/app/controllers/bookmark_of_shuffled_overviews_controller.rb
+++ b/app/controllers/bookmark_of_shuffled_overviews_controller.rb
@@ -27,16 +27,33 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
     
     @date_range = date.beginning_of_day..date.end_of_day
 
-    @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
-    .where(bookmark_of_shuffled_overviews: { created_at: @date_range })
-    .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
-    .joins(:bookmark_of_shuffled_overviews)
-    .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
-    .each_with_object({}) do |overview, hash|
+    if params[:date]
+      @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
+      .where(bookmark_of_shuffled_overviews: { created_at: @date_range })
+      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+      .joins(:bookmark_of_shuffled_overviews)
+      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
+      .each_with_object({}) do |overview, hash|
+        date = overview.date
+        hash[date] ||= []
+        hash[date] << overview
+      end
+    else
+      results = current_user.bookmarked_shuffled_overviews
+      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+      .joins(:bookmark_of_shuffled_overviews)
+      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
+
+      # 結果をハッシュに変換
+      @grouped_bookmarked_shuffled_overviews = results.each_with_object({}) do |overview, hash|
       date = overview.date
       hash[date] ||= []
       hash[date] << overview
+      end
+
+      @grouped_bookmarked_shuffled_overviews.inspect
     end
+
 
     @grouped_bookmarked_shuffled_overviews.inspect
 

--- a/app/views/layouts/_header_navibar.html.erb
+++ b/app/views/layouts/_header_navibar.html.erb
@@ -12,7 +12,7 @@
         <li><%= link_to 'プロフィール', profile_path %></li>
         <li><%= link_to '設定', settings_path %></li>
         <li><%= link_to '作成したあらすじ', user_shuffled_overviews_path(current_user) %></li>
-        <li><%= link_to 'お気に入り' %></li>
+        <li><%= link_to 'お気に入り', user_bookmark_of_shuffled_overviews_path %></li>
         <li><%= link_to 'ログアウト', logout_path, method: :delete %></li>
         </ul>
     </nav>


### PR DESCRIPTION
…追加_#41

## GitHub Issue Ticket

- close #41 

## やった事

`このプルリクエストにて何をしたのか？`
http://localhost:3000/users/1/bookmark_of_shuffled_overviews で
日付を選択していない時に「レコードなし」と表示されてしまうため、
@grouped_bookmarked_shuffled_overviewsの条件分岐を実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
日付ソート機能を実装しているShuffledOverviewモデルレコード、RelatedMovieモデルレコード
と同様の挙動にするため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
params[:date]がない時の@grouped_bookmarked_shuffled_overviewsを
params[:date]がある時と同様にhash化
