### PR TITLE
Feature 2024.08.16.06.43 shuffled overviewモデル movieモデルの多対多のassociationを実装する #66

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,10 +22,7 @@ class ApplicationController < ActionController::Base
   
     # 現在のユーザーを取得
     def current_user
-      # 実際の実装に応じて変更してください
-      @current_user ||= User.find(session[:user_id]) if session[:user_id]
+      @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
     end
-    
-  
   end
   

--- a/app/controllers/bookmark_of_shuffled_overviews_controller.rb
+++ b/app/controllers/bookmark_of_shuffled_overviews_controller.rb
@@ -31,9 +31,9 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
     if params[:date]
       @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
       .where(bookmark_of_shuffled_overviews: { created_at: @date_range })
-      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
       .joins(:bookmark_of_shuffled_overviews)
-      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
+      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
       .each_with_object({}) do |overview, hash|
         date = overview.date
         hash[date] ||= []
@@ -41,9 +41,9 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
       end
     else
       results = current_user.bookmarked_shuffled_overviews
-      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
       .joins(:bookmark_of_shuffled_overviews)
-      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
+      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
 
       # 結果をハッシュに変換
       @grouped_bookmarked_shuffled_overviews = results.each_with_object({}) do |overview, hash|
@@ -125,7 +125,7 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
     tmdb_service = TmdbService.new
     @movies_data = {}
     @bookmarked_shuffled_overviews.each do |bookmarked_shuffled_overview|
-      bookmarked_shuffled_overview.movie_ids.each do |movie_id|
+      bookmarked_shuffled_overview.related_movie_ids.each do |movie_id|
         @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
       end
     end
@@ -137,9 +137,9 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
 
     @grouped_bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
     .where(bookmark_of_shuffled_overviews: { created_at: @date_range })
-    .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+    .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
     .joins(:bookmark_of_shuffled_overviews)
-    .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
+    .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
     .each_with_object({}) do |overview, hash|
       date = overview.date
       hash[date] ||= []

--- a/app/controllers/related_movies_controller.rb
+++ b/app/controllers/related_movies_controller.rb
@@ -50,6 +50,7 @@ class RelatedMoviesController < ApplicationController
   
 
   def filter_movies_by_date
+    Time.zone = 'UTC'
     # 日付パラメータが存在しない場合は Date.today を使用
     date_param = params[:date].presence || Date.today.to_s
     
@@ -61,6 +62,7 @@ class RelatedMoviesController < ApplicationController
     end
     
     @start_date = date
+    date_range = date.beginning_of_day..date.end_of_day
     
     # 現在のユーザーのシャッフルされたあらすじを指定された日付でフィルタリング
     @shuffled_overviews = current_user.shuffled_overviews
@@ -68,6 +70,7 @@ class RelatedMoviesController < ApplicationController
   
     # MySQL クエリで日付ごとの映画カウントを取得
     @grouped_overviews_with_movie_counts = ShuffledOverview
+    .where(created_at: date_range)
     .joins("CROSS JOIN JSON_TABLE(related_movie_ids, '$[*]' COLUMNS (related_movie_id BIGINT PATH '$')) AS movies")
     .select("DATE(created_at) AS date, COUNT(DISTINCT movies.related_movie_id) AS movie_count")
     .group("DATE(created_at)")

--- a/app/controllers/related_movies_controller.rb
+++ b/app/controllers/related_movies_controller.rb
@@ -11,15 +11,15 @@ class RelatedMoviesController < ApplicationController
     tmdb_service = TmdbService.new
     @movies_data = {}
     @shuffled_overviews.each do |shuffled_overview|
-      shuffled_overview.movie_ids.each do |movie_id|
+      shuffled_overview.related_movie_ids.each do |movie_id|
         @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
       end
     end
   
     # MySQL クエリで日付ごとの映画カウントを取得
     @grouped_overviews_with_movie_counts = ShuffledOverview
-    .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
-    .select("DATE(created_at) AS date, COUNT(DISTINCT movies.movie_id) AS movie_count")
+    .joins("CROSS JOIN JSON_TABLE(related_movie_ids, '$[*]' COLUMNS (related_movie_id BIGINT PATH '$')) AS movies")
+    .select("DATE(created_at) AS date, COUNT(DISTINCT movies.related_movie_id) AS movie_count")
     .group("DATE(created_at)")
     .map { |record| [record.date, record.movie_count] }
     .to_h
@@ -34,9 +34,9 @@ class RelatedMoviesController < ApplicationController
     
   def create
     content = shuffled_overview_params[:content]
-    movie_ids = shuffled_overview_params[:movie_ids].map(&:to_i)
+    movie_ids = shuffled_overview_params[:related_movie_ids].map(&:to_i)
   
-    @shuffled_overview = current_user.shuffled_overviews.build(content: content, movie_ids: movie_ids)
+    @shuffled_overview = current_user.shuffled_overviews.build(content: content, related_movie_ids: related_movie_ids)
   
     if @shuffled_overview.save
       Rails.logger.debug "ShuffledOverview movie_ids: #{@shuffled_overview.movie_ids.inspect}"
@@ -53,22 +53,23 @@ class RelatedMoviesController < ApplicationController
     # 日付パラメータが存在しない場合は Date.today を使用
     date_param = params[:date].presence || Date.today.to_s
     
+    
     begin
       date = date_param.to_date
     rescue ArgumentError
       date = Date.today
     end
-  
+    
     @start_date = date
-  
+    
     # 現在のユーザーのシャッフルされたあらすじを指定された日付でフィルタリング
     @shuffled_overviews = current_user.shuffled_overviews
     @grouped_overviews = current_user.shuffled_overviews.where(created_at: @start_date.beginning_of_day..@start_date.end_of_day)
   
     # MySQL クエリで日付ごとの映画カウントを取得
     @grouped_overviews_with_movie_counts = ShuffledOverview
-    .joins("CROSS JOIN JSON_TABLE(movie_ids, '$[*]' COLUMNS (movie_id BIGINT PATH '$')) AS movies")
-    .select("DATE(created_at) AS date, COUNT(DISTINCT movies.movie_id) AS movie_count")
+    .joins("CROSS JOIN JSON_TABLE(related_movie_ids, '$[*]' COLUMNS (related_movie_id BIGINT PATH '$')) AS movies")
+    .select("DATE(created_at) AS date, COUNT(DISTINCT movies.related_movie_id) AS movie_count")
     .group("DATE(created_at)")
     .map { |record| [record.date, record.movie_count] }
     .to_h
@@ -80,20 +81,16 @@ class RelatedMoviesController < ApplicationController
     @movies_data = {}
     
     @grouped_overviews.each do |shuffled_overview|
-      shuffled_overview.movie_ids.each do |movie_id|
+      shuffled_overview.related_movie_ids.each do |movie_id|
         @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
       end
     end
-  
   
     respond_to do |format|
       format.html { render 'users/related_movies/index' }
       format.js   { render 'users/shuffled_overviews/filter_movies_by_date' }
     end
   end
-      
-
-
 
   private
 
@@ -102,7 +99,7 @@ class RelatedMoviesController < ApplicationController
   end
 
   def shuffled_overview_params
-    params.require(:shuffled_overview).permit(:content, movie_ids:[])
+    params.require(:shuffled_overview).permit(:content, related_movie_ids:[])
   end
 
 end

--- a/app/controllers/shuffled_overviews_controller.rb
+++ b/app/controllers/shuffled_overviews_controller.rb
@@ -40,11 +40,17 @@ class ShuffledOverviewsController < ApplicationController
 
   def create
     content = shuffled_overview_params[:content]
-    movie_ids = shuffled_overview_params[:movie_ids].map(&:to_i)
+    related_movie_ids = shuffled_overview_params[:related_movie_ids].map(&:to_i)
   
-    @shuffled_overview = current_user.shuffled_overviews.build(content: content, movie_ids: movie_ids)
+    @shuffled_overview = current_user.shuffled_overviews.build(shuffled_overview_params)
   
+    @shuffled_overview.related_movie_ids.each do |related_movie_id|
+      movie = Movie.find_or_create_by!(tmdb_id: related_movie_id)
+      @shuffled_overview.movies << movie
+    end
+
     if @shuffled_overview.save
+      Rails.logger.debug "ShuffledOverview related_movie_ids: #{@shuffled_overview.related_movie_ids.inspect}"
       Rails.logger.debug "ShuffledOverview movie_ids: #{@shuffled_overview.movie_ids.inspect}"
       logger.debug("ShuffledOverview ID after save: #{@shuffled_overview.id}")
   
@@ -101,7 +107,7 @@ class ShuffledOverviewsController < ApplicationController
   end
 
   def shuffled_overview_params
-    params.require(:shuffled_overview).permit(:content, movie_ids:[])
+    params.require(:shuffled_overview).permit(:content, related_movie_ids:[], movie_ids:[])
   end
 
 end

--- a/app/controllers/shuffled_overviews_controller.rb
+++ b/app/controllers/shuffled_overviews_controller.rb
@@ -59,8 +59,12 @@ class ShuffledOverviewsController < ApplicationController
       render json: { errors: @shuffled_overview.errors.full_messages }, status: :unprocessable_entity
     end
   end
-  
+    
   def filter_shuffled_overviews_by_date
+    Time.zone = 'UTC'
+    date_range = date.beginning_of_day..date.end_of_day
+
+
     # 日付パラメータが存在しない場合は Date.today を使用
     date_param = params[:date].presence || Date.today.to_s
     
@@ -84,7 +88,7 @@ class ShuffledOverviewsController < ApplicationController
     
     # MySQL で日付ごとにカウントを取得
     @grouped_overviews = ShuffledOverview
-                          .where(created_at: date.all_day)
+                          .where(created_at: date_range)
                           .select("DATE(created_at) AS date, COUNT(*) AS count")
                           .group("DATE(created_at)")
                           .map { |record| [record.date.to_date, record.count] }

--- a/app/models/link_of_shuffled_overview_movie.rb
+++ b/app/models/link_of_shuffled_overview_movie.rb
@@ -1,2 +1,4 @@
 class LinkOfShuffledOverviewMovie < ApplicationRecord
+  belongs_to :shuffled_overview
+  belongs_to :movie
 end

--- a/app/models/link_of_shuffled_overview_movie.rb
+++ b/app/models/link_of_shuffled_overview_movie.rb
@@ -1,0 +1,2 @@
+class LinkOfShuffledOverviewMovie < ApplicationRecord
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,2 @@
+class Movie < ApplicationRecord
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,2 +1,4 @@
 class Movie < ApplicationRecord
+  has_many :link_of_shuffled_overview_movies
+  has_many :shuffled_overviews, through: :link_of_shuffled_overview_movies
 end

--- a/app/models/shuffled_overview.rb
+++ b/app/models/shuffled_overview.rb
@@ -1,6 +1,10 @@
 class ShuffledOverview < ApplicationRecord
   belongs_to :user
   validates :content, presence: true
-  has_many :bookmark_of_shuffled_overviews
+  has_many :bookmark_of_shuffled_overviews, dependent: :destroy
   has_many :users, through: :bookmark_of_shuffled_overviews
+  has_many :link_of_shuffled_overview_movies
+  has_many :movies, through: :link_of_shuffled_overview_movies
+  accepts_nested_attributes_for :link_of_shuffled_overview_movies
 end
+

--- a/app/views/movies/show_shuffled_overview.html.erb
+++ b/app/views/movies/show_shuffled_overview.html.erb
@@ -300,7 +300,8 @@ document.addEventListener("DOMContentLoaded", () => {
       body: JSON.stringify({ 
         shuffled_overview: { 
           content: content, 
-          movie_ids: movieIds // 映画のIDを送信
+          related_movie_ids: movieIds, // 映画のIDを送信
+          tmdb_ids: movieIds // 映画のIDを送信
         } 
       })
     })

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
@@ -6,7 +6,7 @@
           <div class="shuffled-overview-item">
             <div class="movie-images-container">
               <div class="movie-images">
-                <% bookmarked_shuffled_overview.movie_ids.each do |movie_id| %>
+                <% bookmarked_shuffled_overview.related_movie_ids.each do |movie_id| %>
                   <% movie = @movies_data[movie_id] %>
                   <% if movie && movie['poster_path'] %>
                     <%= link_to movie_path(movie_id) do %>

--- a/app/views/users/related_movies/_shuffled_overviews_count_calendar_for_related_movies.html.erb
+++ b/app/views/users/related_movies/_shuffled_overviews_count_calendar_for_related_movies.html.erb
@@ -168,8 +168,8 @@ document.addEventListener("DOMContentLoaded", () => {
         link.addEventListener('click', event => {
           event.preventDefault();
           const baseUrl = event.target.closest('a').href;
-          // URLのパスが"/filter_movies_by_date" で終わる場合に追加する
-          const url = `${baseUrl.replace(/\/filter_movies_by_date\/.*$/, '')}/filter_movies_by_date/${formattedDate}`;
+          # // URLのパスが"/filter_movies_by_date" で終わる場合に追加する
+          # const url = `${baseUrl.replace(/\/filter_movies_by_date\/.*$/, '')}/filter_movies_by_date/${formattedDate}`;
   
           fetch(url, {
             headers: {

--- a/app/views/users/shuffled_overviews/filter_movies_by_date.js.erb
+++ b/app/views/users/shuffled_overviews/filter_movies_by_date.js.erb
@@ -1,1 +1,2 @@
+console.log('app/views/users/shuffled_overviews/filter_movies_by_date.js.erb')
 document.querySelector('.related-movie-images').innerHTML = "<%= j render partial: 'users/related_movies/related_movie_list', locals: { movies_data: @movies_data } %>";

--- a/db/migrate/20240814112419_create_movies.rb
+++ b/db/migrate/20240814112419_create_movies.rb
@@ -1,0 +1,10 @@
+class CreateMovies < ActiveRecord::Migration[7.1]
+  def change
+    create_table :movies do |t|
+      t.integer :tmdb_id
+
+      t.timestamps
+    end
+    add_index :movies, :tmdb_id
+  end
+end

--- a/db/migrate/20240814215223_create_link_of_shuffled_overview_movies.rb
+++ b/db/migrate/20240814215223_create_link_of_shuffled_overview_movies.rb
@@ -1,0 +1,12 @@
+class CreateLinkOfShuffledOverviewMovies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :link_of_shuffled_overview_movies do |t|
+      t.references :shuffled_overview, null: false, foreign_key: true
+      t.references :movie, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :link_of_shuffled_overview_movies, [:shuffled_overview_id, :movie_id], unique: true, name: 'index_shuffled_overview_movie_ids'
+  end
+end

--- a/db/migrate/20240815114208_rename_movie_ids_to_related_movie_ids_in_shuffled_overviews.rb
+++ b/db/migrate/20240815114208_rename_movie_ids_to_related_movie_ids_in_shuffled_overviews.rb
@@ -1,0 +1,5 @@
+class RenameMovieIdsToRelatedMovieIdsInShuffledOverviews < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :shuffled_overviews, :movie_ids, :related_movie_ids
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,6 +21,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_114208) do
     t.index ["user_id"], name: "index_bookmark_of_shuffled_overviews_on_user_id"
   end
 
+  create_table "link_of_shuffled_overview_movies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "shuffled_overview_id", null: false
+    t.bigint "movie_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["movie_id"], name: "index_link_of_shuffled_overview_movies_on_movie_id"
+    t.index ["shuffled_overview_id", "movie_id"], name: "index_shuffled_overview_movie_ids", unique: true
+    t.index ["shuffled_overview_id"], name: "index_link_of_shuffled_overview_movies_on_shuffled_overview_id"
+  end
+
   create_table "movies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "tmdb_id"
     t.datetime "created_at", null: false
@@ -59,6 +69,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_114208) do
 
   add_foreign_key "bookmark_of_shuffled_overviews", "shuffled_overviews"
   add_foreign_key "bookmark_of_shuffled_overviews", "users"
+  add_foreign_key "link_of_shuffled_overview_movies", "movies"
+  add_foreign_key "link_of_shuffled_overview_movies", "shuffled_overviews"
   add_foreign_key "settings", "users"
   add_foreign_key "shuffled_overviews", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_04_142451) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_15_114208) do
   create_table "bookmark_of_shuffled_overviews", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "shuffled_overview_id", null: false
@@ -19,6 +19,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_04_142451) do
     t.index ["shuffled_overview_id"], name: "index_bookmark_of_shuffled_overviews_on_shuffled_overview_id"
     t.index ["user_id", "shuffled_overview_id"], name: "index_bookmarks_on_user_and_overview", unique: true
     t.index ["user_id"], name: "index_bookmark_of_shuffled_overviews_on_user_id"
+  end
+
+  create_table "movies", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "tmdb_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tmdb_id"], name: "index_movies_on_tmdb_id"
   end
 
   create_table "settings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,7 +52,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_15_114208) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "movie_ids"
+    t.json "related_movie_ids"
     t.index ["user_id"], name: "index_shuffled_overviews_on_user_id"
   end
 

--- a/test/fixtures/link_of_shuffled_overview_movies.yml
+++ b/test/fixtures/link_of_shuffled_overview_movies.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  shuffled_overview: one
+  movie: one
+
+two:
+  shuffled_overview: two
+  movie: two

--- a/test/fixtures/movies.yml
+++ b/test/fixtures/movies.yml
@@ -1,11 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+one:
+  tmdb_id: 1
+
+two:
+  tmdb_id: 1

--- a/test/models/link_of_shuffled_overview_movie_test.rb
+++ b/test/models/link_of_shuffled_overview_movie_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LinkOfShuffledOverviewMovieTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## GitHub Issue Ticket
- close #66 
- close #71

## やった事
`このプルリクエストにて何をしたのか？`
中間テーブル `LinkOfShuffledOverviewMovie`モデルを作成し、
`ShuffledOverview` - `LinkOfShuffledOverviewMovie` - `Movie` の多対多のassociationを実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
あらすじに使われた映画をブックマークできるような機能を実装するため、
あらすじが保存された時点で、そのあらすじに使われた映画の情報をデータベースに保存する必要ありと考えた。

ShuffledOverviewモデルに持たせていたmovie_idsから、映画をブックマークするなどの追加のステータスを
実装するにはShuffledOverviewモデルのカラムが増えることが懸念された
```
ShuffledOverview.attribute_names
=> ["id", "content", "user_id", "created_at", "updated_at", "movie_ids"]
``` 

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
Movieモデルのid movie_idと競合するためにカラム名を変更
```
ShuffledOverview.attribute_names
=> ["id", "content", "user_id", "created_at", "updated_at", "movie_ids"]
``` 
```
ShuffledOverview.attribute_names
=> ["id", "content", "user_id", "created_at", "updated_at", "related_movie_ids"]
``` 
