### PR TITLE
Feature_2024.08.18.02.21_ブックマークしたあらすじの一覧画面で映画画像を通常のあらすじ一覧画面でも同様に表示する_#75

### DIFF
--- a/app/controllers/bookmark_of_shuffled_overviews_controller.rb
+++ b/app/controllers/bookmark_of_shuffled_overviews_controller.rb
@@ -52,7 +52,6 @@ class BookmarkOfShuffledOverviewsController < ApplicationController
       hash[date] << overview
       end
 
-      @grouped_bookmarked_shuffled_overviews.inspect
     end
 
 

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list.html.erb
@@ -7,9 +7,9 @@
             <div class="movie-images-container">
               <div class="movie-images">
                 <% bookmarked_shuffled_overview.related_movie_ids.each do |movie_id| %>
-                  <% movie = @movies_data[movie_id] %>
+                  <% movie ||= TmdbService.new.fetch_movie_details(movie_id) %>
                   <% if movie && movie['poster_path'] %>
-                    <%= link_to movie_path(movie_id) do %>
+                    <%= link_to related_movie_path(movie_id) do %>
                       <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
                     <% end %>
                   <% end %>


### PR DESCRIPTION
## GitHub Issue Ticket

- close #75 

## やった事
`このプルリクエストにて何をしたのか？`
画面による表示されている要素の有無の違いの解消
 - ブックマークされたあらすじ BookmarkOfShuffledOverviewモデルレコード の一覧画面
   - 映画の画像が表示されていない
 - 通常のあらすじ ShuffledOverviewモデルレコードの一覧画面
   - 映画の画像が表示されている

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
画面による機能の違いを解消

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
なし

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし