### PR TITLE
Feature_2024.08.18.15.56_あらすじ一覧の横に表示される映画画像にブックマークボタンを実装する_#80

### DIFF
--- a/app/views/related_movies/_bookmark_add_button.html.erb
+++ b/app/views/related_movies/_bookmark_add_button.html.erb
@@ -4,7 +4,7 @@ remote: true,
 id: "bookmark-add-button-related-movie-#{movie_id}",
 class: "bookmark-link",
 data: { action: 'bookmark' } do %>
-  <i class="fa-regular fa-3x fa-heart"></i>
+  <i class="fa-regular fa-2x fa-heart"></i>
 <% end %>
 
 <style>
@@ -23,7 +23,7 @@ data: { action: 'bookmark' } do %>
 .bookmark-link {
   border: none;
   cursor: pointer;
-  color: #fff;
+  color:  #ffb5b5;
 }
 
 .bookmark-link i {

--- a/app/views/related_movies/_bookmark_remove_button.html.erb
+++ b/app/views/related_movies/_bookmark_remove_button.html.erb
@@ -4,7 +4,7 @@ remote: true,
 id: "bookmark-remove-button-related-movie-#{movie_id}",
 class: "bookmark-link",
 data: { action: 'unbookmark' }  do %>
-  <i class="fa fa-3x fa-heart"></i>
+  <i class="fa fa-2x fa-heart"></i>
 <% end %>
 
 <style>
@@ -23,7 +23,8 @@ data: { action: 'unbookmark' }  do %>
 .bookmark-link {
   border: none;
   cursor: pointer;
-  color: #fff;
+  color:  #ffb5b5;
+  opacity: 0.8;
 }
 
 .bookmark-link i {

--- a/app/views/users/shuffled_overviews/_shuffled_overview_list.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overview_list.html.erb
@@ -6,9 +6,18 @@
           <div class="movie-images">
             <% shuffled_overview.related_movie_ids.each do |movie_id| %>
               <% movie = @movies_data[movie_id] %>
-              <%= link_to related_movie_path(movie_id) do %>
-                <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
-              <% end %>
+              <div class="movie-image-wrapper">
+                <%= link_to related_movie_path(movie_id) do %>
+                  <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+                <% end %>
+                <div class="button-container">
+                  <% if current_user.bookmarked_movies.exists?(tmdb_id: movie_id) %>
+                    <%= render partial: 'related_movies/bookmark_remove_button', locals: { movie_id: movie_id } %>
+                  <% else %>
+                    <%= render partial: 'related_movies/bookmark_add_button', locals: { movie_id: movie_id } %>
+                  <% end %>
+                </div>
+              </div>
             <% end %>
           </div>
         </div>
@@ -70,6 +79,7 @@
   display: flex;
   flex-direction: column; /* 画像を縦に並べる */
   margin-right: 20px; /* あらすじとの間隔を調整 */
+  position: relative; /* 相対位置に設定 */
 }
 
 .movie-images {
@@ -78,10 +88,22 @@
   gap: 10px; /* 画像間の間隔 */
 }
 
+.movie-image-wrapper {
+  position: relative; /* 子要素の絶対位置に基づく */
+}
+
 .movie-images img {
   max-width: 100px; /* 画像の幅を制限 */
   max-height: 150px; /* 画像の高さを制限 */
   object-fit: cover; /* 画像が領域に収まるように調整 */
+}
+
+.button-container {
+  position: absolute; /* 絶対位置に設定 */
+  bottom: 10px; /* 画像の下部に位置 */
+  right: 10px; /* 画像の右部に位置 */
+  display: flex;
+  gap: 10px; /* ボタン間の間隔 */
 }
 
 .shuffled-overview-content {
@@ -98,9 +120,5 @@
 .button-container {
   text-align: center;
   gap: 10px;
-}
-
-.bookmark-container {
-  background-color: none;
 }
 </style>


### PR DESCRIPTION
## GitHub Issue Ticket

- #80 

## やった事
`このプルリクエストにて何をしたのか？`
あらすじの一覧画面で表示される映画画像にブックマークボタンを実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
他の画面で映画をブックマークできるが、
あらすじ一覧画面でブックマークできないという機能が不統一な部分があるため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
のちに別途テストを実装する

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
なし