### PR TITLE
Style 2024.08.19.00.22 リンクアイコン（ブックマーク済の映画一覧画面へのリンク）のスタイリング #86

### DIFF
--- a/app/views/users/bookmark_of_shuffled_overviews/index.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/index.html.erb
@@ -16,9 +16,11 @@
  <div class="calendar-toggle" id="calendar-icon-for-filtering-bookmarked-shuffled-overviews">
    <i class="fa fa-3x fa-calendar"></i>
  </div>
- <div>
-   <%= link_to user_related_movies_path, class:"link-to-related-movies" do %>
-     <i class="fa fa-3x fa-film"></i>
+ <div class="count-wrapper">
+   <%= link_to user_bookmark_of_movies_path, class:"link-to-related-movies" do %>
+    <span class="count"><%= current_user.bookmarked_movies.count %></span>
+    <i class="fa fa-3x fa-film"></i>
+    <i class="fas fa-heart"></i>
    <% end %>
  </div>
 </div>
@@ -99,6 +101,51 @@
   max-width: 100%;
   max-height: 150px;
   display: block;
+}
+
+.count-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.count-wrapper .fa-book-open { /* アイコンのサイズと色 */
+  font-size: 24px; /* アイコンのサイズを適宜調整 */
+  color: #2c4c64;
+}
+
+.count-wrapper .count {
+  position: absolute;
+  top: -9px; /* 上方向の調整 */
+  right: -18px; /* 右方向の調整 */
+  background-color: red; /* カウント数の丸の背景色 */
+  color: white; /* カウント数のテキストの色 */
+  border-radius: 50%; /* 丸い形にする */
+  padding: 2px; /* テキスト周りの余白 */
+  font-size: 12px; /* テキストサイズ */
+  line-height: 1;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px; /* 丸の幅を固定 */
+  height: 24px; /* 丸の高さを固定 */
+}
+
+.count-wrapper .fa-heart {
+  position: absolute;
+  top: 30px;
+  right: -12px;
+  color: red;
+  border-radius: 50%;
+  padding: 2px;
+  font-size: 6px;
+  line-height: 1;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 18px;
+  height: 18px;
 }
 
 </style>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
       end
     end
     resources :bookmark_of_movies, only: [:index]
-    resources :bookmark_of_movies, only: [:index] do
+    resources :bookmark_of_movies, only:[] do
       collection do
         get 'filter_bookmarked_movies_by_date/:date', action: :filter_bookmarked_movies_by_date, as: :filter_bookmarked_movies_by_date
       end


### PR DESCRIPTION
## GitHub Issue Ticket

- close #86

## やった事
`このプルリクエストにて何をしたのか？`
 - ブックマーク済の映画一覧であることがわかるようにハートアイコンを追加
 - レコード個数を動的に表示


 - 変更前 ![image](https://github.com/user-attachments/assets/59e00a9a-b7f6-4f10-a66f-af9b11d166ab)
 - 変更後 ![image](https://github.com/user-attachments/assets/e11029ff-3172-4caf-ac3f-8b14ebcde4ee)

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
 - リンクアイコン（ブックマーク済の映画一覧画面へのリンク） が、通常の映画一覧画面へのリンクアイコンと同じため、リンク先も同じように見えるため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
テストを別途作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
