### PR TITLE
Feature 2024.08.19.03.44 プロフィール画面に自分のブックマークしたあらすじを表示するようにする #95

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,9 @@ class UsersController < ApplicationController
     end
   end
 
+  def profile
+  end
+      
   private
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,19 @@ class UsersController < ApplicationController
   end
 
   def profile
+    results = current_user.bookmarked_shuffled_overviews
+      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
+      .joins(:bookmark_of_shuffled_overviews)
+      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
+      .order('date DESC')
+      .limit(4) # ここでレコードを5つに制限
+  
+    # 結果をハッシュに変換
+    @grouped_bookmarked_shuffled_overviews = results.each_with_object({}) do |overview, hash|
+      date = overview.date
+      hash[date] ||= []
+      hash[date] << overview
+    end
   end
       
   private

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,19 +7,19 @@
       <%= link_to shuffled_overview_path, class:"header-link-of-shuffled-overview" do %>
         <i class="fa fa-pencil fa-2x"></i>
         <div>あらすじ</div>
+      <% end %>
+    </div>
+    <div class="user-info">
+      <% if current_user.avatar? %>
+        <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
+          <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+          <div class="user-name"><%= current_user.name %></div>
         <% end %>
-        </div>
-        <div class="user-info">
-        <% if current_user.avatar? %>
-          <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
-            <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
-            <div class="user-name"><%= current_user.name %></div>
-          <% end %>
-        <% else %>
-          <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
-            <i class="fa fa-user-circle fa-2x"></i>
-            <div class="user-name"><%= current_user.name %></div>
-          <% end %>
+      <% else %>
+        <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
+          <i class="fa fa-user-circle fa-2x"></i>
+          <div class="user-name"><%= current_user.name %></div>
+        <% end %>
       <% end %>
     </div>
     <%= render 'layouts/header_navibar' %>

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list_on_profile.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list_on_profile.html.erb
@@ -1,0 +1,254 @@
+<div class="content">
+  <div class="bookmarked-shuffled-overview-list">
+  <div class="bookmarked-shuffled-overview-list-title">
+    <div class="title-wrapper">
+      <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+      <i class="fas fa-heart"></i>
+    </div>
+    <div>
+      ブックマークしたあらすじ
+    </div>
+    <div class="title-wrapper">
+      <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+      <i class="fas fa-heart"></i>
+    </div>
+  </div>
+
+  </div>
+    <% if @grouped_bookmarked_shuffled_overviews.present? %>
+      <% @grouped_bookmarked_shuffled_overviews.each do |date, overviews| %>
+        <% overviews.each do |bookmarked_shuffled_overview| %>
+          <div class="shuffled-overview-item">
+            <div class="movie-images-container">
+              <div class="movie-images">
+                <% bookmarked_shuffled_overview.related_movie_ids.each do |movie_id| %>
+                  <% movie ||= TmdbService.new.fetch_movie_details(movie_id) %>
+                  <% if movie && movie['poster_path'] %>
+                    <div class="movie-image-wrapper">
+                      <%= link_to related_movie_path(movie_id) do %>
+                        <img src="https://image.tmdb.org/t/p/w200<%= movie['poster_path'] %>" alt="Movie Poster">
+                      <% end %>
+                    </div>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+            <div class="shuffled-overview-content">
+              <%= truncate(strip_tags(bookmarked_shuffled_overview.content), length: 50, omission: '...') %>
+              <%= link_to user_shuffled_overview_path(user_id: current_user.id, id: bookmarked_shuffled_overview.id), class: "link-to-more-shuffled-overview" do %>
+                <i class="fa-solid fa-1x fa-magnifying-glass-plus"></i>
+              <% end %>
+            </div>
+            <div class="button-container">
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p>指定された日付にはブックマークされたシャッフル概要がありません。</p>
+    <% end %>
+  </div>
+</div>
+
+<style>
+.btn {
+  background: #b2ebf2;
+  color: #00796b;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  transition: background 0.3s;
+  height: 50px;
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  flex-direction: row;
+  max-width: 60%;
+  margin-left: 10px;
+}
+
+.bookmarked-shuffled-overview-list {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column; /* 縦並びにする */
+  width: 80%; /* 横幅を調整 */
+  box-sizing: border-box;
+}
+
+.bookmarked-shuffled-overview-list-title {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.title-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.title-wrapper .fa-book-open { /* アイコンのサイズと色 */
+  font-size: 24px; /* アイコンのサイズを適宜調整 */
+  color: #2c4c64;
+}
+
+.title-wrapper .count {
+  position: absolute;
+  top: -16px; /* 上方向の調整 */
+  right: -18px; /* 右方向の調整 */
+  background-color: red; /* カウント数の丸の背景色 */
+  color: white; /* カウント数のテキストの色 */
+  border-radius: 50%; /* 丸い形にする */
+  padding: 2px; /* テキスト周りの余白 */
+  font-size: 12px; /* テキストサイズ */
+  line-height: 1;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px; /* 丸の幅を固定 */
+  height: 24px; /* 丸の高さを固定 */
+}
+
+.title-wrapper .fa-heart {
+  position: absolute;
+  top: 12px;
+  right: -12px;
+  color: red;
+  border-radius: 50%;
+  padding: 2px;
+  font-size: 6px;
+  line-height: 1;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+}
+
+
+
+.shuffled-overview-item {
+  display: flex; /* 横並びにする */
+  align-items: flex-start; /* 上揃え */
+  margin-bottom: 10px;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+  width: 40%; /* 横幅を100%にして、親コンテナ内での幅を調整 */
+  box-sizing: border-box;
+  margin-right: 10px;
+}
+
+.movie-images-container {
+  display: flex;
+  flex-direction: column; /* 画像を縦に並べる */
+  margin-right: 20px; /* あらすじとの間隔を調整 */
+}
+
+.movie-images {
+  display: flex; /* 画像を横並びにする */
+  flex-direction: row; /* 横並びに設定 */
+  gap: 10px; /* 画像間の間隔 */
+}
+
+.movie-images img {
+  max-width: 75px; /* 画像の幅を制限 */
+  max-height: 150px; /* 画像の高さを制限 */
+  object-fit: cover; /* 画像が領域に収まるように調整 */
+}
+
+.shuffled-overview-content {
+  font-size: 16px;
+  margin-bottom: 10px;
+  flex: 1; /* コンテンツが残りのスペースを占めるようにする */
+}
+
+.shuffled-overview-meta {
+  display: flex;
+  font-size: 12px;
+  color: #888;
+  gap: 10px;
+}
+
+.movie-image-wrapper {
+  position: relative; /* 子要素の絶対位置に基づく */
+}
+
+.button-container {
+  display: flex;
+  gap: 10px; /* ボタン間の間隔 */
+}
+
+.button-container-for-shuffled-overview {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  align-items: center;
+}
+
+.link-to-more-shuffled-overview {
+  color: black;
+}
+
+.movie-link {
+  color: black;
+  text-decoration: none;
+}
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const popup = document.getElementById('movie-info-popup');
+  const popupTitle = document.getElementById('popup-title');
+  const popupImage = document.getElementById('popup-image');
+
+  function enableLinksAndHoverEvents() {
+    document.querySelectorAll('.movie-link').forEach(link => {
+      link.addEventListener('mouseover', (event) => {
+        const movieInfo = event.target.dataset.movieInfo;
+        const movieImage = event.target.dataset.movieImage;
+        popupTitle.textContent = movieInfo;
+        popupImage.src = movieImage;
+
+        popup.style.display = 'block';
+
+        let top = event.clientY + window.scrollY + 10;
+        let left = event.clientX + window.scrollX + 10;
+
+        const popupWidth = popup.offsetWidth;
+        const popupHeight = popup.offsetHeight;
+
+        if (left + popupWidth > window.innerWidth + window.scrollX) {
+          left = window.innerWidth + window.scrollX - popupWidth - 10;
+        }
+
+        if (top + popupHeight > window.innerHeight + window.scrollY) {
+          top = window.innerHeight + window.scrollY - popupHeight - 10;
+        }
+
+        popup.style.top = `${top}px`;
+        popup.style.left = `${left}px`;
+      });
+
+      link.addEventListener('mouseout', () => {
+        popup.style.display = 'none';
+      });
+    });
+  }
+
+  function attachEventListeners() {
+    enableLinksAndHoverEvents();
+  }
+
+  attachEventListeners(); // 初期のDOMContentLoaded時のイベントリスナーの設定
+});
+</script>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,0 +1,167 @@
+<div>
+  <div class="user-info-on-profile">
+    <% if current_user.avatar? %>
+      <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
+        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+        <div class="user-name"><%= current_user.name %></div>
+      <% end %>
+    <% else %>
+      <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
+        <i class="fa fa-user-circle fa-2x"></i>
+        <div class="user-name"><%= current_user.name %></div>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div>
+    <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews: @msy_bookmarked_shuffled_overviews } %>
+  </div>
+</div>
+
+<div id="movie-info-popup" class="hidden">
+  <div id="popup-title"></div>
+  <img id="popup-image" src="" alt="Movie Image">
+</div>
+
+<style>
+.user-info-on-profile {
+  display: flex;
+  justify-content: center;
+}
+
+
+.shuffled-overview-list {
+  display: flex;
+  flex-flow: column;
+  flex-wrap: nowrap;
+  align-items: center;
+  margin-top: 100px;
+  margin-bottom: 100px;
+
+  .shuffled-overview-item {
+    margin-bottom: 20px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background-color: #f9f9f9;
+    width: 100%; /* 横幅を調整 */
+    box-sizing: border-box;
+
+    .shuffled-overview-content {
+      font-size: 16px;
+      margin-bottom: 10px;
+    }
+  }
+}
+
+.shuffled-overview-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.movie-link {
+    text-decoration: none;
+    color: black;
+}
+
+.button-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: row;
+}
+
+#movie-info-popup {
+  position: absolute;
+  display: none;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+  z-index: 1000;
+  max-width: 300px;
+  max-height: 200px;
+  overflow: hidden;
+}
+
+#popup-image {
+  max-width: 100%;
+  max-height: 150px;
+  display: block;
+}
+
+form.button_to {
+  width: 30px;
+}
+
+.bookmark-add-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  black;
+  cursor: pointer;
+}
+
+
+.bookmark-remove-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  #ffb5b5;
+  cursor: pointer;
+}
+</style>
+
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const popup = document.getElementById('movie-info-popup');
+  const popupTitle = document.getElementById('popup-title');
+  const popupImage = document.getElementById('popup-image');
+
+  function enableLinksAndHoverEvents() {
+    document.querySelectorAll('.movie-link').forEach(link => {
+      link.addEventListener('mouseover', (event) => {
+        const movieInfo = event.target.dataset.movieInfo;
+        const movieImage = event.target.dataset.movieImage;
+        popupTitle.textContent = movieInfo;
+        popupImage.src = movieImage;
+
+        popup.style.display = 'block';
+
+        let top = event.clientY + window.scrollY + 10;
+        let left = event.clientX + window.scrollX + 10;
+
+        const popupWidth = popup.offsetWidth;
+        const popupHeight = popup.offsetHeight;
+
+        if (left + popupWidth > window.innerWidth + window.scrollX) {
+          left = window.innerWidth + window.scrollX - popupWidth - 10;
+        }
+
+        if (top + popupHeight > window.innerHeight + window.scrollY) {
+          top = window.innerHeight + window.scrollY - popupHeight - 10;
+        }
+
+        popup.style.top = `${top}px`;
+        popup.style.left = `${left}px`;
+      });
+
+      link.addEventListener('mouseout', () => {
+        popup.style.display = 'none';
+      });
+    });
+  }
+
+  function attachEventListeners() {
+    enableLinksAndHoverEvents();
+  });
+
+  attachEventListeners(); // 初期のDOMContentLoaded時のイベントリスナーの設定
+
+  // コンテンツが動的にロードされた後にイベントリスナーを再設定
+  document.addEventListener('ajax:success', (event) => {
+    attachEventListeners();
+  });
+});
+
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,10 +7,10 @@ Rails.application.routes.draw do
   get 'logout', to: 'sessions#destroy'  #
   delete 'logout', to: 'sessions#destroy'  #
   resources :users, only: [:new, :create, :destroy]
-  resources :settings, only: [:index, :show]
     # サインアップ関連のルーティング（仮定）
   get 'signup', to: 'users#new', as: :signup
-  get 'profile', to: 'users#show', as: :profile
+  get 'settings', to: 'users#show', as: :settings
+  get 'profile', to: 'users#profile', as: :profile
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   resource :users, only: [] do


### PR DESCRIPTION
## GitHub Issue Ticket
- close #95 

## やった事
`このプルリクエストにて何をしたのか？`
プロフィール画面に、自分のブックマークしたあらすじの一覧（直近4つを表示）

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
プロフィール画面の内容の充実

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
テストを別途作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
ブックマーク済のあらすじの表示を直近4つにしたのは、スタイルの問題。
プロフィール画面に表示しきれないことを懸念した。
