### PR TITLE
Feature_2024.08.19.07.01_プロフィール画面にブックマークした映画を表示するように実装

### DIFF
--- a/app/views/users/bookmark_of_movies/_bookmarked_movies_list_on_profile.html.erb
+++ b/app/views/users/bookmark_of_movies/_bookmarked_movies_list_on_profile.html.erb
@@ -1,0 +1,188 @@
+<div class="bookmarked-movies-list-title">
+  <div class="title-wrapper">
+    <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+    <i class="fas fa-heart"></i>
+  </div>
+  <div>
+    <%= link_to user_bookmark_of_movies_path(current_user), class:"title-wrapper" do %>
+    ブックマークした映画
+    <% end %>
+  </div>
+  <div class="title-wrapper">
+    <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+    <i class="fas fa-heart"></i>
+  </div>
+</div>
+<div class="related-movie-images">
+  <% @bookmarked_movies_by_date.each do |date, tmdb_ids| %>
+    <% tmdb_ids.each do |tmdb_id| %>
+      <div class="related-movie-image-wrapper">
+        <%= link_to related_movie_path(tmdb_id) do %>
+          <img src="https://image.tmdb.org/t/p/w200<%= movie_poster_path(tmdb_id) %>" alt="映画ポスター" class="related-movie-image">
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<style>
+.bookmarked-movies-list-title {
+  position: fixed;
+  top: 25%;
+  left: 60%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+.related-movie-images {
+  position: fixed;
+  top: 30%;
+  left: 52%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.related-movie-image-wrapper {
+  position: relative;
+  display: inline-block;
+  margin: 10px; /* 画像間の余白を調整 */
+}
+
+.related-movie-image {
+  display: block;
+  width: 100%; /* 必要に応じてサイズを調整 */
+  height: 150px;
+}
+
+.button-container {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+}
+
+.bookmark-link {
+  color: white;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color:  #ffb5b5;
+}
+
+form.button_to {
+  width: 30px;
+}
+
+.bookmark-add-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  black;
+  cursor: pointer;
+}
+
+.bookmark-remove-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  #ffb5b5;
+  cursor: pointer;
+}
+
+.button-container {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+}
+
+.bookmark-link {
+  color: white;
+  border-radius: 50%;
+  text-decoration: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color:  #ffb5b5;
+}
+
+form.button_to {
+  width: 30px;
+}
+
+.bookmark-add-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  black;
+  cursor: pointer;
+}
+
+.bookmark-remove-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  #ffb5b5;
+  cursor: pointer;
+}
+
+.bookmarked-shuffled-overview-list-title {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.title-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  color: black;
+  margin-right: 5px;
+  margin-left: 5px;
+}
+
+.title-wrapper .fa-book-open { /* アイコンのサイズと色 */
+  font-size: 24px; /* アイコンのサイズを適宜調整 */
+  color: #2c4c64;
+}
+
+.title-wrapper .count {
+  position: absolute;
+  top: -16px; /* 上方向の調整 */
+  right: -18px; /* 右方向の調整 */
+  background-color: red; /* カウント数の丸の背景色 */
+  color: white; /* カウント数のテキストの色 */
+  border-radius: 50%; /* 丸い形にする */
+  padding: 2px; /* テキスト周りの余白 */
+  font-size: 12px; /* テキストサイズ */
+  line-height: 1;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px; /* 丸の幅を固定 */
+  height: 24px; /* 丸の高さを固定 */
+}
+
+.title-wrapper .fa-heart {
+  position: absolute;
+  top: 12px;
+  right: -12px;
+  color: red;
+  border-radius: 50%;
+  padding: 2px;
+  font-size: 6px;
+  line-height: 1;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 16px;
+  height: 16px;
+}
+
+</style>

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list_on_profile.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list_on_profile.html.erb
@@ -1,19 +1,20 @@
 <div class="content">
   <div class="bookmarked-shuffled-overview-list">
-  <div class="bookmarked-shuffled-overview-list-title">
-    <div class="title-wrapper">
-      <i class="fas fa-book-open" style="color: #2c4c64;"></i>
-      <i class="fas fa-heart"></i>
+    <div class="bookmarked-shuffled-overview-list-title-on-profile">
+      <div class="title-wrapper">
+        <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+        <i class="fas fa-heart"></i>
+      </div>
+      <div>
+        <%= link_to user_bookmark_of_shuffled_overviews_path(current_user), class:"title-wrapper" do %>
+        ブックマークしたあらすじ
+        <% end %>
+      </div>
+      <div class="title-wrapper">
+        <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+        <i class="fas fa-heart"></i>
+      </div>
     </div>
-    <div>
-      ブックマークしたあらすじ
-    </div>
-    <div class="title-wrapper">
-      <i class="fas fa-book-open" style="color: #2c4c64;"></i>
-      <i class="fas fa-heart"></i>
-    </div>
-  </div>
-
   </div>
     <% if @grouped_bookmarked_shuffled_overviews.present? %>
       <% @grouped_bookmarked_shuffled_overviews.each do |date, overviews| %>
@@ -69,6 +70,9 @@
   flex-direction: row;
   max-width: 60%;
   margin-left: 10px;
+  position: fixed;
+  top: 30%;
+  left: 1%;
 }
 
 .bookmarked-shuffled-overview-list {
@@ -79,9 +83,11 @@
   box-sizing: border-box;
 }
 
-.bookmarked-shuffled-overview-list-title {
-  position: relative;
+.bookmarked-shuffled-overview-list-title-on-profile {
+  position: fixed;
   display: inline-flex;
+  top: 25%;
+  left: 15%;
   justify-content: center;
   align-items: center;
   gap: 10px;
@@ -93,6 +99,8 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  text-decoration: none;
+  color: black;
 }
 
 .title-wrapper .fa-book-open { /* アイコンのサイズと色 */

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="profile">
   <div class="user-info-on-profile">
     <% if current_user.avatar? %>
       <%= link_to profile_path, class:"header-link-of-shuffled-overview" do %>
@@ -15,6 +15,7 @@
 
   <div>
     <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews: @msy_bookmarked_shuffled_overviews } %>
+    <%= render partial: 'users/bookmark_of_movies/bookmarked_movies_list_on_profile', locals: { bookmarked_movies_by_date: @bookmarked_movies_by_date } %>
   </div>
 </div>
 
@@ -24,7 +25,14 @@
 </div>
 
 <style>
+.profile {
+  margin-top: 100px;
+}
+
 .user-info-on-profile {
+  position: fixed;
+  top: 15%;
+  left: 50%;
   display: flex;
   justify-content: center;
 }


### PR DESCRIPTION
## GitHub Issue Ticket

- close #97 

## やった事
`このプルリクエストにて何をしたのか？`
プロフィール画面(users#profile)でブックマークした映画を表示されるように実装

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
プロフィール機能の充実化

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途テスト作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
下記のように別々にrenderしたパーシャルファイルに対し、
横に配置するスタイルが効かなかったため　`position: fixed;`で各ファイル内容を配置
```ruby
  <div>
    <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews: @msy_bookmarked_shuffled_overviews } %>
    <%= render partial: 'users/bookmark_of_movies/bookmarked_movies_list_on_profile', locals: { bookmarked_movies_by_date: @bookmarked_movies_by_date } %>
  </div>

``` 