### PR TITLE
Feature 2024.08.22.21.20 shuffled overviewモデルレコードからcharacterモデルレコード（登場人物）を抽出生成する機能を実装する #109

### DIFF
--- a/app/controllers/shuffled_overviews_controller.rb
+++ b/app/controllers/shuffled_overviews_controller.rb
@@ -62,10 +62,11 @@ class ShuffledOverviewsController < ApplicationController
 
   def update
     @shuffled_overview = ShuffledOverview.find(params[:id])
+    
     if @shuffled_overview.update(shuffled_overview_params)
-      extract_characters(@shuffled_overview.content) if @shuffled_overview.content.present?
+      extract_characters
       respond_to do |format|
-        format.html { redirect_to @shuffled_overview, notice: 'Shuffled overview was successfully updated.' }
+        format.html { redirect_to user_shuffled_overview_path(@shuffled_overview), notice: 'Shuffled overview was successfully updated.' }
         format.js   # For AJAX requests
       end
     else
@@ -115,16 +116,19 @@ class ShuffledOverviewsController < ApplicationController
 
   private
 
-  def extract_characters(content)
-    characters = CharacterExtractorService.extract_and_assign_characters(content)
-    characters.each do |character|
+  def extract_characters
+    content = @shuffled_overview.content
+    character_names = CharacterExtractorService.extract_and_assign_characters(content)
+
+    character_names.each do |character_name|
+      character = Character.find_or_create_by(name: character_name)  # 名前からCharacterオブジェクトを検索または作成
       AppearanceOfCharacter.find_or_create_by(
         shuffled_overview: @shuffled_overview,
         character: character
       )
     end
   end
-
+  
   def set_user
     @user = current_user
   end

--- a/app/views/shuffled_overviews/update.js.erb
+++ b/app/views/shuffled_overviews/update.js.erb
@@ -1,0 +1,5 @@
+<% if @characters.present? %>
+  <% @characters.each do |character| %>
+    $("#characters-list").append("<%= j render partial: 'character', locals: { character: character } %>");
+  <% end %>
+<% end %>


### PR DESCRIPTION
## GitHub Issue Ticket
- close #109 
  - close #108

## やった事
`このプルリクエストにて何をしたのか？`
Characterモデルレコードの抽出条件を追加
 - 国の名前や、地名はCharacterモデルレコードとして保存しないようにする
 - 出力する名前の中で重複を排除する
   -「トム」という名前の登場人物に対し「 トムトム」 というような登場人物のレコードが現れないようにする

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
Characterレコードとして近いものが抽出されるようにする。

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途テスト作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
`gem 'active_json'`