### PR TITLE
Feature_2024.08.25.01.53_「⚪︎⚪︎の△△」のようにキーワードを抽出する機能を追加する #115

### DIFF
--- a/app/services/keyword_extractor_service.rb
+++ b/app/services/keyword_extractor_service.rb
@@ -9,6 +9,8 @@ class KeywordExtractorService
     return if content.nil? || shuffled_overview.nil?
 
     keywords = []
+
+    # 1. ENCLOSED_PATTERNSからキーワードを抽出
     ENCLOSED_PATTERNS.each do |pattern|
       content.scan(pattern).each do |matched_text|
         keyword_content = matched_text.strip
@@ -16,9 +18,47 @@ class KeywordExtractorService
       end
     end
 
+    # 2. NEologdを使って「名詞 + の + 名詞」のパターンを抽出
+    titles = extract_noun_phrases(content)
+    titles.each do |title|
+      keywords << title unless keywords.include?(title)
+    end
+
+    # 3. キーワードをShuffledOverviewに関連付け
     keywords.each do |keyword_content|
       keyword = Keyword.find_or_create_by(content: keyword_content)
       shuffled_overview.keywords << keyword unless shuffled_overview.keywords.include?(keyword)
     end
+  end
+
+  private
+
+  def self.extract_noun_phrases(content)
+    require 'natto'
+
+    natto = Natto::MeCab.new
+    titles = []
+    buffer = []
+
+    natto.parse(content) do |n|
+      if n.feature.start_with?('名詞')
+        buffer << n.surface  # 名詞をバッファに追加
+      elsif n.surface == 'の' && buffer.any?
+        buffer << n.surface  # 名詞の後の「の」をバッファに追加
+      else
+        # パターンが「名詞 の 名詞」であることを確認
+        if buffer.length >= 3 && buffer[1] == 'の'
+          titles << buffer.join
+        end
+        buffer.clear  # バッファをクリア
+      end
+    end
+
+    # 最後のバッファのチェック
+    if buffer.length >= 3 && buffer[1] == 'の'
+      titles << buffer.join
+    end
+
+    titles
   end
 end

--- a/app/views/users/shuffled_overviews/show.html.erb
+++ b/app/views/users/shuffled_overviews/show.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="shuffled-overview-page">
   <div class="shuffled-overview-container">
     <div id="shuffled-overview-generating-container">
       <div id="shuffled-overview-title">あらすじ</div>
@@ -53,11 +53,16 @@
 </div>
   
 <style>
+.shuffled-overview-page {
+  overflow-y: auto; /* 縦スクロールを許可 */
+}
+
 /* コンテナ全体のスタイリング */
 .shuffled-overview-container {
   position: relative;
   width: 1200px; /* 固定幅 */
   margin: 0 auto; /* コンテナを中央に配置 */
+  margin-top: 15px;
   background: #e0f7fa; /* 薄い明るい青 */
   border-radius: 240px 15px 100px 15px / 15px 200px 15px 185px;
   border: 3px solid #333;
@@ -347,5 +352,4 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 });
-
 </script>


### PR DESCRIPTION
## GitHub Issue Ticket
- close #114
- close #115

## やった事
`このプルリクエストにて何をしたのか？`
キーワードとしてあらすじから「⚪︎⚪︎の△△」を抽出するように変更

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途テスト作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
