### PR TITLE
Bug 2024.08.28.06.03 プロフィール画面で表示する項目によってプロフィールヘッダーの位置が変わる #122

### DIFF
--- a/app/controllers/bookmark_of_movies_controller.rb
+++ b/app/controllers/bookmark_of_movies_controller.rb
@@ -1,6 +1,8 @@
 class BookmarkOfMoviesController < ApplicationController
   before_action :set_movie, only: [:bookmark, :unbookmark]
   helper_method :movie_poster_path
+  before_action :set_user
+
 
   def index
     Time.zone = 'UTC'
@@ -128,6 +130,10 @@ class BookmarkOfMoviesController < ApplicationController
 
   def set_movie
     @movie = Movie.find_or_create_by(tmdb_id: params[:id])
+  end
+
+  def set_user
+    @user = current_user
   end
 
   

--- a/app/controllers/bookmark_of_shuffled_overviews_controller.rb
+++ b/app/controllers/bookmark_of_shuffled_overviews_controller.rb
@@ -1,5 +1,6 @@
 class BookmarkOfShuffledOverviewsController < ApplicationController
   # before_action :authenticate_user!
+  before_action :set_user
 
   def index
     @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
@@ -176,4 +177,8 @@ end
 
   def set_shuffled_overview
     @shuffled_overview = ShuffledOverview.find(params[:shuffled_overview_id])
+  end
+
+  def set_user
+    @user = current_user
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,6 +58,12 @@ class UsersController < ApplicationController
       hash[date] << overview
     end
 
+    @grouped_bookmarked_movies = current_user.bookmarked_movies
+    .select('DATE(bookmark_of_movies.created_at) AS date, movies.tmdb_id, COUNT(*) AS count')
+    .joins(:bookmark_of_movies)
+    .group('DATE(bookmark_of_movies.created_at), movies.tmdb_id')
+
+
     filtered_bookmarked_movies = current_user.bookmarked_movies
     .select('DATE(bookmark_of_movies.created_at) AS date, movies.tmdb_id')
     .joins(:bookmark_of_movies)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,6 +79,13 @@ class UsersController < ApplicationController
       @bookmarked_movies_by_date[date] << tmdb_id
     end
 
+    @bookmarked_movies_data = {}
+
+    current_user.bookmarked_movies.each do |movie|
+      tmdb_id = movie.tmdb_id
+      @bookmarked_movies_data[tmdb_id] ||= tmdb_service.fetch_movie_details(tmdb_id)
+    end
+
   end
 
   def movie_poster_path(tmdb_id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   skip_before_action :require_login
   helper_method :movie_poster_path
+  before_action :set_user
 
   def new
     @user = User.new
@@ -33,6 +34,15 @@ class UsersController < ApplicationController
     @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
 
     @shuffled_overviews = current_user.shuffled_overviews
+
+    tmdb_service = TmdbService.new
+    @movies_data = {}
+    @shuffled_overviews.each do |shuffled_overview|
+      shuffled_overview.related_movie_ids.each do |movie_id|
+        @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
+      end
+    end
+
     # <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews: @msy_bookmarked_shuffled_overviews } %>で渡す変数
     results = current_user.bookmarked_shuffled_overviews
       .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
@@ -73,6 +83,10 @@ class UsersController < ApplicationController
   end
       
   private
+
+  def set_user
+    @user = current_user
+  end
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)

--- a/app/views/users/bookmark_of_movies/_bookmarked_movies_list.html.erb
+++ b/app/views/users/bookmark_of_movies/_bookmarked_movies_list.html.erb
@@ -65,40 +65,4 @@ form.button_to {
   color:  #ffb5b5;
   cursor: pointer;
 }
-
-.button-container {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-}
-
-.bookmark-link {
-  color: white;
-  border-radius: 50%;
-  text-decoration: none;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color:  #ffb5b5;
-}
-
-form.button_to {
-  width: 30px;
-}
-
-.bookmark-add-button {
-  background: none;
-  border: none;
-  padding: 0;
-  color:  black;
-  cursor: pointer;
-}
-
-.bookmark-remove-button {
-  background: none;
-  border: none;
-  padding: 0;
-  color:  #ffb5b5;
-  cursor: pointer;
-}
 </style>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -162,6 +162,7 @@
 /* 既存のスタイルはそのまま */
 .tab-content {
   display: none; /* 初期状態では非表示 */
+  min-height: 550px;
 }
 
 .tab-content.active {
@@ -300,6 +301,7 @@
 }
 
 .profile-body {
+  position:relative;
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -324,31 +324,12 @@
   display: block;
 }
 
-form.button_to {
-  width: 30px;
-}
-
-.bookmark-add-button {
-  background: none;
-  border: none;
-  padding: 0;
-  color:  black;
-  cursor: pointer;
-}
-
-
-.bookmark-remove-button {
-  background: none;
-  border: none;
-  padding: 0;
-  color:  #ffb5b5;
-  cursor: pointer;
-}
 </style>
 
 
 <script>
 document.addEventListener("DOMContentLoaded", () => {
+  // Movie info popup
   const popup = document.getElementById('movie-info-popup');
   const popupTitle = document.getElementById('popup-title');
   const popupImage = document.getElementById('popup-image');
@@ -389,14 +370,91 @@ document.addEventListener("DOMContentLoaded", () => {
 
   function attachEventListeners() {
     enableLinksAndHoverEvents();
-  });
+    document.querySelectorAll('.read-aloud-button').forEach(button => {
+      button.addEventListener('click', (event) => {
+        const container = event.target.closest('.shuffled-overview-item').querySelector('.shuffled-overview-content');
+        readAloud(container.textContent);
+      });
+    });
+
+    document.querySelectorAll('.stop-button').forEach(button => {
+      button.addEventListener('click', stopReading);
+    });
+  }
 
   attachEventListeners(); // 初期のDOMContentLoaded時のイベントリスナーの設定
+
+  async function getVoices() {
+    return new Promise(resolve => {
+      let synth = window.speechSynthesis;
+      let id;
+
+      id = setInterval(() => {
+        if (synth.getVoices().length !== 0) {
+          resolve(synth.getVoices());
+          clearInterval(id);
+        }
+      }, 10);
+    });
+  }
+
+  let voices = [];
+
+  async function readAloud(text) {
+    if (voices.length === 0) {
+      voices = await getVoices();
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'ja-JP';
+
+    const voiceName = 'Kyoko';
+    const voice = voices.find(v => v.name.includes(voiceName)) || voices[0];
+    utterance.voice = voice;
+
+    speechSynthesis.speak(utterance);
+  }
+
+  function stopReading() {
+    speechSynthesis.cancel();
+  }
 
   // コンテンツが動的にロードされた後にイベントリスナーを再設定
   document.addEventListener('ajax:success', (event) => {
     attachEventListeners();
   });
-});
 
+  // タブ切り替え用のスクリプト
+  const tabLinks = document.querySelectorAll('.tab-link');
+  const tabContents = document.querySelectorAll('.tab-content');
+
+  tabLinks.forEach(link => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      // すべてのタブリンクとタブコンテンツを非アクティブに
+      tabLinks.forEach(link => link.classList.remove('active'));
+      tabContents.forEach(content => content.classList.remove('active'));
+
+      // クリックされたタブリンクをアクティブに
+      link.classList.add('active');
+
+      // 対応するタブコンテンツをアクティブに
+      const target = link.dataset.target;
+      const targetContent = document.querySelector(target);
+      if (targetContent) {
+        targetContent.classList.add('active');
+      }
+    });
+  });
+
+  // タブの状態をURLのハッシュに基づいて設定
+  const hash = window.location.hash;
+  if (hash) {
+    const activeTabLink = document.querySelector(`.tab-link[data-target="${hash}-content"]`);
+    if (activeTabLink) {
+      activeTabLink.click();
+    }
+  }
+});
 </script>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -82,7 +82,23 @@
         </div>
       </li>
       <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+            <div>
+              <%= link_to '#bookmarked_my_movies', class: "header-selection-wrapper tab-link", data: { target: "#bookmarked-my-movies-content" }, onclick: "event.preventDefault(); window.location.href='/profile#bookmarked_my_movies';" do %>
                 いいね<p style="font-size:12px;">(映画)</p>
+              <% end %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
       </li>
       <li>
                実績
@@ -98,6 +114,9 @@
     </div>
     <div id="my-movies-content" class="tab-content">
       <%= render partial: 'users/related_movies/related_movie_list', locals: { movies_data: @movies_data } %>
+    </div>
+    <div id="bookmarked-my-movies-content" class="tab-content">
+      <%= render partial: 'users/bookmark_of_movies/bookmarked_movies_list', locals: { bookmarked_movies_by_date: @bookmarked_movies_by_date } %>
     </div>
   </div>
 </div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -140,59 +140,170 @@
   <img id="popup-image" src="" alt="Movie Image">
 </div>
 
+
 <style>
-.profile {
-  margin-top: 100px;
+.tab-link.active {
+  position: relative; /* 擬似要素のために必要 */
+  color: black; /* リンクの色 */
 }
 
-.user-info-on-profile {
-  position: fixed;
-  top: 15%;
-  left: 50%;
+.tab-link.active::after {
+  content: "";
+  position: absolute;
+  bottom: 0; /* リンクの下部に配置 */
+  left: 0;
+  width: 100%;
+  height: 2px; /* ボーダーの高さ */
+  background-color: blue; /* 青線の色 */
+  border-radius: 0; /* ボーダーの丸みをなくす */
+  z-index: 1; /* ボーダーがリンクの下に表示されないように */
+}
+
+/* 既存のスタイルはそのまま */
+.tab-content {
+  display: none; /* 初期状態では非表示 */
+}
+
+.tab-content.active {
+  display: block; /* アクティブなコンテンツを表示 */
+}
+
+/* 他のスタイル */
+.bookmarked-shuffled-overview-list {
+  margin-top: 10px;
   display: flex;
+  flex-direction: column; /* 縦並びにする */
+  width: 100%; /* 横幅を調整 */
+  box-sizing: border-box;
+}
+
+.bookmarked-shuffled-overview-list-title-on-profile {
+  display: inline-flex;
   justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
 }
 
-
-.shuffled-overview-list {
-  display: flex;
-  flex-flow: column;
-  flex-wrap: nowrap;
+.header-selection-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
   align-items: center;
-  margin-top: 100px;
-  margin-bottom: 100px;
+  text-decoration: none;
+  color: black;
 
-  .shuffled-overview-item {
-    margin-bottom: 20px;
-    padding: 10px;
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    background-color: #f9f9f9;
-    width: 100%; /* 横幅を調整 */
-    box-sizing: border-box;
-
-    .shuffled-overview-content {
-      font-size: 16px;
-      margin-bottom: 10px;
-    }
+  .fa-heart {
+    color: red; /* アイコンの色を赤に変更（任意） */
+    font-size: 14px; /* アイコンのサイズを調整（任意） */
+    vertical-align: middle; /* テキストとアイコンを垂直方向に中央揃え */
   }
 }
 
-.shuffled-overview-meta {
-  font-size: 12px;
-  color: #888;
+.profile {
+  position: relative; /* 絶対配置から相対配置に変更 */
+  top: 110px;
+  left: 10px;
+  width: calc(100%); /* 画面幅いっぱいに広げる（左マージンの10px分を考慮） */
 }
 
-.movie-link {
-    text-decoration: none;
-    color: black;
-}
-
-.button-container {
+.user-info-on-profile {
+  z-index: ;
   display: flex;
-  justify-content: center;
+  justify-content: space-between; /* アバターとフォロー情報を左右に配置 */
   align-items: center;
+}
+
+.follow-info {
+  display: flex;
   flex-direction: row;
+  text-align: right;
+  position: absolute;
+  top: 0;
+  right: 30px;
+  gap: 30px;
+}
+
+.user-avatar-on-profile {
+  display: flex;
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.user-avatar-wrapper {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+}
+
+.user-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.user-name {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.profile-contents {
+  margin-top: 20px;
+}
+
+.profile-header {
+  position: relative;
+  width: 100%;
+  background-color: #f8f8f8;
+  box-sizing: border-box;
+  top: -20px;
+}
+
+.profile-header ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  justify-content: flex-start;
+  gap: 75px;
+  margin-left: 50px;
+  align-items: center;
+}
+
+.profile-header li {
+  font-size: 1.2rem;
+}
+
+.profile-header a {
+  text-decoration: none;
+  color: black;
+  border-radius: 20px; /* 丸みを帯びたボタン風 */
+  position: relative; /* 擬似要素の位置を調整するために必要 */
+  transition: background-color 0.3s ease;
+}
+
+.profile-header a.active::after {
+  content: "";
+  position: absolute;
+  bottom: -2px; /* ボーダーをリンクの下に配置 */
+  left: 0;
+  width: 100%;
+  height: 6px; /* ボーダーの高さ */
+  background: rgba(0, 0, 255, 0.5); /* グレーの蛍光ペン風の色 */
+  box-shadow: 0 0 4px rgba(0, 0, 255, 0.2); /* 蛍光ペン風の影 */
+  border-radius: 0; /* 丸みをなくす */
+}
+
+.profile-header a:hover {
+  background-color: #f0f0f0; /* ホバー時の背景色変更 */
+}
+
+.profile-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-top: 20px;
 }
 
 #movie-info-popup {

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -127,10 +127,10 @@
       <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { bookmarked_shuffled_overviews: @bookmarked_shuffled_overviews } %>
     </div>
     <div id="my-movies-content" class="tab-content">
-      <%= render partial: 'users/related_movies/related_movie_list', locals: { movies_data: @movies_data } %>
+      <%= render partial: 'users/related_movies/related_movie_list_on_profile', locals: { movies_data: @movies_data } %>
     </div>
     <div id="bookmarked-my-movies-content" class="tab-content">
-      <%= render partial: 'users/bookmark_of_movies/bookmarked_movies_list', locals: { bookmarked_movies_by_date: @bookmarked_movies_by_date } %>
+      <%= render partial: 'users/bookmark_of_movies/bookmarked_movies_list_on_profile', locals: { bookmarked_movies_data: @bookmarked_movies_data } %>
     </div>
   </div>
 </div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -101,7 +101,21 @@
         </div>
       </li>
       <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-2x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+              <%= link_to user_bookmark_of_shuffled_overviews_path(current_user), class:"header-selection-wrapper" do %>
                実績
+              <% end %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-2x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
       </li>
     </ul>
   </div>

--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -65,7 +65,21 @@
         </div>
       </li>
       <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+              <%= link_to '#my_movies', class: "header-selection-wrapper tab-link", data: { target: "#my-movies-content" }, onclick: "event.preventDefault(); window.location.href='/profile#my_movies';" do %>
                 映画一覧
+              <% end %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
       </li>
       <li>
                 いいね<p style="font-size:12px;">(映画)</p>
@@ -81,6 +95,9 @@
     </div>
     <div id="bookmarked-my-shuffled-overviews-content" class="tab-content">
       <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list', locals: { bookmarked_shuffled_overviews: @bookmarked_shuffled_overviews } %>
+    </div>
+    <div id="my-movies-content" class="tab-content">
+      <%= render partial: 'users/related_movies/related_movie_list', locals: { movies_data: @movies_data } %>
     </div>
   </div>
 </div>

--- a/app/views/users/related_movies/_related_movie_list_on_profile.html.erb
+++ b/app/views/users/related_movies/_related_movie_list_on_profile.html.erb
@@ -1,5 +1,5 @@
 <div class="related-movie-images">
-  <% @bookmarked_movies_data.each do |movie_id, movie| %>
+  <% @movies_data.each do |movie_id, movie| %>
     <div class="related-movie-image-wrapper">
       <%= link_to related_movie_path(movie_id) do %>
         <img src="https://image.tmdb.org/t/p/w92<%= movie['poster_path'] %>" alt="Movie Poster" class="related-movie-image">


### PR DESCRIPTION
## GitHub Issue Ticket

- close #122 

## やった事

`このプルリクエストにて何をしたのか？`
 - データ構造の統一化 564b0265c5fb4d98f43b6d4c5d456d128c40957d
   - 変更前
     -  データ構造が違う変数をviewに渡している　（`@movies_data`と`@bookmarked_movies_by_date`）
       - 動画一覧 `app/views/users/related_movies/_related_movie_list.html.erb`
         - `@movies_data` をviewに渡している
       - いいねした動画一覧 `app/views/users/bookmark_of_movies/_bookmarked_movies_list.html.erb`
         - `@bookmarked_movies_by_date` をviewに渡している
   - 変更後
     -  データ構造が同じ変数をviewに渡すように変更　（`@movies_data`と`@bookmarked_movies_data`）
       - 動画一覧 `app/views/users/related_movies/_related_movie_list_on_profile.html.erb`
         - `@movies_data` をviewに渡している
       - いいねした動画一覧 `app/views/users/bookmark_of_movies/_bookmarked_movies_list_on_profile.html.erb`
         - `@bookmarked_movies_data`**（新規作成）** をviewに渡す
 - プロフィール画面の表示要素のmin-heightを設定 e27ded3a8889b3b98abaf651b35d596d79b67ff5
   - プロフィール画面上で表示する数によって行数が異なるため、列が少ないとヘッダーが下へ表示されるのを改善

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
表示する項目によってプロフィールフッターの表示位置が変わるのを防ぎたい

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途テスト追加予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
