### PR TITLE
Feature_2024.09.01.07.58_プロフィールの映画一覧画面のスタイル・機能を実装_#135

### DIFF
--- a/app/views/users/profile.html.erb
+++ b/app/views/users/profile.html.erb
@@ -140,7 +140,6 @@
   <div class="tab-content" id="bookmarked-my-shuffled-overviews-content">
     <div class="pagination-on-profile">
       <div>
-        <%= paginate @bookmarked_shuffled_overviews_on_profile %>
         <%= paginate @bookmarked_shuffled_overviews_on_profile, param_name: :bookmarked_shuffled_overviews_page %>
       </div>
     </div>
@@ -156,8 +155,16 @@
         <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews_on_profile: @bookmarked_shuffled_overviews_on_profile } %>
     </div>
   </div>
+  <div class="tab-content" id="my-movies-content">
+    <div class="pagination-on-profile">
+    </div>
+    <div class="scroll-indicator">
+    </div>
+    <div class="profile-body">
+        <%= render partial: 'users/related_movies/related_movie_list_on_profile', locals: { movies_data: @movies_data } %>
+    </div>
+  </div>
 </div>
-
 
 <div id="movie-info-popup" class="hidden">
   <div id="popup-title"></div>

--- a/app/views/users/related_movies/_related_movie_list_on_profile.html.erb
+++ b/app/views/users/related_movies/_related_movie_list_on_profile.html.erb
@@ -2,7 +2,7 @@
   <% @movies_data.each do |movie_id, movie| %>
     <div class="related-movie-image-wrapper">
       <%= link_to related_movie_path(movie_id) do %>
-        <img src="https://image.tmdb.org/t/p/w92<%= movie['poster_path'] %>" alt="Movie Poster" class="related-movie-image">
+        <img src="https://image.tmdb.org/t/p/w185<%= movie['poster_path'] %>" alt="Movie Poster" class="related-movie-image">
       <% end %>
       <div class="button-container">
         <% if current_user.bookmarked_movies.exists?(tmdb_id: movie['id']) %>


### PR DESCRIPTION
## GitHub Issue Ticket

- close #135

## やった事
`このプルリクエストにて何をしたのか？`
プロフィール画面における映画一覧画面を他の画面と統一

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
プロフィール画面の機能統一

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
映画一覧画面には下記は実装しないこととした
 - ページネーションボタン
 - スクロールボタン