### PR TITLE
Feature_2024.09.05.05.53_マイページのあらすじにあらすじ詳細ボタンを追加する_#149

### DIFF
--- a/app/views/users/shuffled_overviews/_shuffled_overview_list_on_profile.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overview_list_on_profile.html.erb
@@ -60,6 +60,9 @@
         <div class="shuffled-overview-content" id="shuffled-overview-content-<%= shuffled_overview.id %>">
           <% sanitized_content = strip_tags(shuffled_overview.content) %>
           <%= truncate(sanitized_content, length: 200, omission: '...') %>
+          <div class="shuffled-overview-meta">
+            <p>保存日時: <%= shuffled_overview.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+          </div>
           <% if sanitized_content.length > 200 %>
             <div class="read-more-button" data-id="<%= shuffled_overview.id %>">
               <i class="fa-solid fa-2x fa-magnifying-glass-plus"></i>
@@ -67,11 +70,16 @@
           <% end %>
           <div class="shuffled-overview-content-full" id="full-content-<%= shuffled_overview.id %>" style="display: none;">
             <%= raw shuffled_overview.content %>
+            <div class="shuffled-overview-meta">
+              <p>保存日時: <%= shuffled_overview.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+            </div>
           </div>
-          <div class="shuffled-overview-meta">
-            <p>保存日時: <%= shuffled_overview.created_at.strftime("%Y-%m-%d %H:%M:%S") %></p>
+          <div class="link-icon-to-shuffled-overview-show">
+            <%= link_to user_shuffled_overview_path(current_user, shuffled_overview) do%>
+              <i class="fa-solid fa-arrow-up-right-from-square"></i>
+            <% end %>
           </div>
-          </div>
+        </div>
       </div>
     <% end %>
   </div>
@@ -122,18 +130,34 @@
   width: 95%;
   height: 100%;
   box-sizing: border-box;
+  margin-top: 10px;
 }
 
 
 .shuffled-overview-item {
+  position: relative; 
   display: flex; /* 横並びにする */
   align-items: flex-start; /* 上揃え */
   margin-bottom: 20px;
   border: 1px solid #ddd;
   border-radius: 5px;
   background-color: #f9f9f9;
+  padding: 20px;
   width: 100%; /* 横幅を100%にして、親コンテナ内での幅を調整 */
   box-sizing: border-box;
+}
+
+.link-icon-to-shuffled-overview-show {
+  position: absolute;
+  top: 10px; /* Adjust as needed to place the icon slightly away from the top */
+  right: 10px; /* Adjust as needed to place the icon slightly away from the right */
+  font-size: 18px; /* Adjust the size of the icon as needed */
+  cursor: pointer;
+}
+
+.link-icon-to-shuffled-overview-show i {
+  display: block;
+  color: #333; /* Change the color to match your design */
 }
 
 .movie-images-container {


### PR DESCRIPTION
## GitHub Issue Ticket
- close #149 

## やった事
`このプルリクエストにて何をしたのか？`
マイページのあらすじにあらすじ詳細画面へのリンクボタンを追加

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
マイページとタイムラインの機能の統一

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途テスト実装予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
