### PR TITLE
Feature 2024.09.11.06.49 jsで実装しているマイページの切り替え表示機能をバックエンドで実装 #156

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,11 +31,41 @@ class UsersController < ApplicationController
   end
 
   def mypage
-    @bookmarked_shuffled_overviews = current_user.bookmarked_shuffled_overviews
-
-    @shuffled_overviews = current_user.shuffled_overviews
     @shuffled_overviews_on_profile = current_user.shuffled_overviews.page(params[:shuffled_overviews_page]).per(5)
 
+    tmdb_service = TmdbService.new
+    @movies_data = {}
+
+    # ユニークな movie_id を取得する
+    unique_movie_ids = @shuffled_overviews_on_profile.flat_map(&:related_movie_ids).uniq
+
+    # ユニークな movie_id を使って映画の詳細をフェッチ
+    unique_movie_ids.each do |movie_id|
+      @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
+    end
+    @movies_array = @movies_data.values
+    @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
+  end
+
+  def mypage_shuffled_overviews
+    @shuffled_overviews_on_profile = current_user.shuffled_overviews.page(params[:shuffled_overviews_page]).per(5)
+
+    tmdb_service = TmdbService.new
+    @movies_data = {}
+
+    # ユニークな movie_id を取得する
+    unique_movie_ids = @shuffled_overviews_on_profile.flat_map(&:related_movie_ids).uniq
+
+    # ユニークな movie_id を使って映画の詳細をフェッチ
+    unique_movie_ids.each do |movie_id|
+      @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
+    end
+    @movies_array = @movies_data.values
+    @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
+  end
+
+
+  def mypage_bookmarked_shuffled_overviews
     # Bookmarked ShuffledOverviewsのIDを取得
     bookmarked_shuffled_overview_ids = current_user.bookmarked_shuffled_overviews.pluck(:shuffled_overview_id)
 
@@ -44,15 +74,9 @@ class UsersController < ApplicationController
 
     tmdb_service = TmdbService.new
     @movies_data = {}
-    @movies_data_related_of_bookmarked_overviews = {}
-    # @shuffled_overviews.each do |shuffled_overview|
-    #   shuffled_overview.related_movie_ids.each do |movie_id|
-    #     @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
-    #   end
-    # end
 
     # ユニークな movie_id を取得する
-    unique_movie_ids = @shuffled_overviews.flat_map(&:related_movie_ids).uniq
+    unique_movie_ids = @bookmarked_shuffled_overviews_on_profile.flat_map(&:related_movie_ids).uniq
 
     # ユニークな movie_id を使って映画の詳細をフェッチ
     unique_movie_ids.each do |movie_id|
@@ -60,58 +84,35 @@ class UsersController < ApplicationController
     end
     @movies_array = @movies_data.values
     @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
-    
-    
-    @bookmarked_shuffled_overviews_on_profile.each do |shuffled_overview|
-      shuffled_overview.related_movie_ids.each do |movie_id|
-        @movies_data_related_of_bookmarked_overviews[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
-      end
+  end
+
+  def mypage_my_movies
+    tmdb_service = TmdbService.new
+    @movies_data = {}
+
+    # ユニークな movie_id を取得する
+    unique_movie_ids = current_user.shuffled_overviews.flat_map(&:related_movie_ids).uniq
+
+    # ユニークな movie_id を使って映画の詳細をフェッチ
+    unique_movie_ids.each do |movie_id|
+      @movies_data[movie_id] ||= tmdb_service.fetch_movie_details(movie_id)
     end
-    
-    
-    # <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews: @msy_bookmarked_shuffled_overviews } %>で渡す変数
-    results = current_user.bookmarked_shuffled_overviews
-      .select('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at) AS date, COUNT(*) AS count')
-      .joins(:bookmark_of_shuffled_overviews)
-      .group('shuffled_overviews.id, shuffled_overviews.content, shuffled_overviews.related_movie_ids, DATE(bookmark_of_shuffled_overviews.created_at)')
-      .order('date DESC')
-      .limit(4) # ここでレコードを5つに制限
+    @movies_array = @movies_data.values
+    @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
+  end
   
-    # 結果をハッシュに変換
-    @grouped_bookmarked_shuffled_overviews = results.each_with_object({}) do |overview, hash|
-      date = overview.date
-      hash[date] ||= []
-      hash[date] << overview
-    end
-
-    @grouped_bookmarked_movies = current_user.bookmarked_movies
-    .select('DATE(bookmark_of_movies.created_at) AS date, movies.tmdb_id, COUNT(*) AS count')
-    .joins(:bookmark_of_movies)
-    .group('DATE(bookmark_of_movies.created_at), movies.tmdb_id')
-
-
-    filtered_bookmarked_movies = current_user.bookmarked_movies
-    .select('DATE(bookmark_of_movies.created_at) AS date, movies.tmdb_id')
-    .joins(:bookmark_of_movies)
-    .group('DATE(bookmark_of_movies.created_at), movies.tmdb_id')
-    .limit(4)
-
-    # 常に配列を値として持つハッシュを初期化
-    @bookmarked_movies_by_date = Hash.new { |hash, key| hash[key] = [] }
-
-    filtered_bookmarked_movies.each do |movie|
-      date = movie.date
-      tmdb_id = movie.tmdb_id
-      @bookmarked_movies_by_date[date] << tmdb_id
-    end
-
+  def mypage_bookmarked_my_movies
+    tmdb_service = TmdbService.new
+    
     @bookmarked_movies_data = {}
-
+    
     current_user.bookmarked_movies.each do |movie|
       tmdb_id = movie.tmdb_id
       @bookmarked_movies_data[tmdb_id] ||= tmdb_service.fetch_movie_details(tmdb_id)
     end
-
+    
+    @movies_array = @bookmarked_movies_data.values
+    @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
   end
 
   def movie_poster_path(tmdb_id)

--- a/app/views/users/mypage_bookmarked_my_movies.html.erb
+++ b/app/views/users/mypage_bookmarked_my_movies.html.erb
@@ -36,7 +36,10 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -49,7 +52,11 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
             </div>
           </div>
         </div>
@@ -58,10 +65,13 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -70,11 +80,45 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link active" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -82,22 +126,13 @@
     </ul>
   </div>
 
-  <div class="tab-content active" id="my-shuffled-overviews-content">
-    <div class="pagination-on-profile active">
-      <div>
-        <%= paginate @shuffled_overviews_on_profile, param_name: :shuffled_overviews_page %>
-      </div>
+  <div class="tab-content active" id="bookmarked-my-movies-content">
+    <div class="pagination-on-profile">
     </div>
     <div class="scroll-indicator">
-      <div class="scroll-downforward-indicator">
-        <i class="fas fa-chevron-down scroll-indicator-icon"></i>
-      </div>
-      <div class="scroll-upforward-indicator">
-        <i class="fas fa-chevron-up scroll-indicator-icon"></i>
-      </div>
     </div>
     <div class="profile-body">
-        <%= render partial: 'users/shuffled_overviews/shuffled_overview_list_on_profile', locals: { shuffled_overviews_on_profile: @shuffled_overviews_on_profile } %>
+        <%= render partial: 'users/bookmark_of_movies/bookmarked_movies_list_on_profile', locals: {bookmarked_movies_data: @bookmarked_movies_data } %>
     </div>
   </div>
 </div>
@@ -193,12 +228,10 @@
 
 /* 既存のスタイルはそのまま */
 .tab-content {
-  display: none; /* 初期状態では非表示 */
   min-height: 550px;
 }
 
 .tab-content.active {
-  display: block; /* アクティブなコンテンツを表示 */
 }
 
 /* 他のスタイル */
@@ -499,6 +532,7 @@ document.addEventListener("DOMContentLoaded", () => {
     attachEventListeners();
   });
 
+
 const profileBody = document.querySelector('.profile-body');
 const scrollDownforwardIndicator = document.querySelector('.scroll-downforward-indicator');
 const scrollUpforwardIndicator = document.querySelector('.scroll-upforward-indicator');
@@ -525,7 +559,5 @@ scrollUpforwardIndicator.addEventListener('click', function () {
   scrollProfileBody('up');
 });  
 });
-
-document.addEventListener("DOMContentLoaded", anchorKeeper);
 
 </script>

--- a/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
@@ -36,7 +36,10 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -49,7 +52,11 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
             </div>
           </div>
         </div>
@@ -58,10 +65,13 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -70,11 +80,45 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -82,10 +126,11 @@
     </ul>
   </div>
 
-  <div class="tab-content active" id="my-shuffled-overviews-content">
-    <div class="pagination-on-profile active">
+
+  <div class="tab-content" id="bookmarked-my-shuffled-overviews-content">
+    <div class="pagination-on-profile">
       <div>
-        <%= paginate @shuffled_overviews_on_profile, param_name: :shuffled_overviews_page %>
+        <%= paginate @bookmarked_shuffled_overviews_on_profile, param_name: :bookmarked_shuffled_overviews_page %>
       </div>
     </div>
     <div class="scroll-indicator">
@@ -97,7 +142,7 @@
       </div>
     </div>
     <div class="profile-body">
-        <%= render partial: 'users/shuffled_overviews/shuffled_overview_list_on_profile', locals: { shuffled_overviews_on_profile: @shuffled_overviews_on_profile } %>
+        <%= render partial: 'users/bookmark_of_shuffled_overviews/bookmarked_shuffled_overview_list_on_profile', locals: { bookmarked_shuffled_overviews_on_profile: @bookmarked_shuffled_overviews_on_profile } %>
     </div>
   </div>
 </div>
@@ -193,12 +238,7 @@
 
 /* 既存のスタイルはそのまま */
 .tab-content {
-  display: none; /* 初期状態では非表示 */
   min-height: 550px;
-}
-
-.tab-content.active {
-  display: block; /* アクティブなコンテンツを表示 */
 }
 
 /* 他のスタイル */

--- a/app/views/users/mypage_my_movies.html.erb
+++ b/app/views/users/mypage_my_movies.html.erb
@@ -36,7 +36,10 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -49,7 +52,11 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
             </div>
           </div>
         </div>
@@ -58,10 +65,13 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link active" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -70,11 +80,45 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -82,22 +126,14 @@
     </ul>
   </div>
 
-  <div class="tab-content active" id="my-shuffled-overviews-content">
-    <div class="pagination-on-profile active">
-      <div>
-        <%= paginate @shuffled_overviews_on_profile, param_name: :shuffled_overviews_page %>
-      </div>
+
+  <div class="tab-content active" id="my-movies-content">
+    <div class="pagination-on-profile">
     </div>
     <div class="scroll-indicator">
-      <div class="scroll-downforward-indicator">
-        <i class="fas fa-chevron-down scroll-indicator-icon"></i>
-      </div>
-      <div class="scroll-upforward-indicator">
-        <i class="fas fa-chevron-up scroll-indicator-icon"></i>
-      </div>
     </div>
     <div class="profile-body">
-        <%= render partial: 'users/shuffled_overviews/shuffled_overview_list_on_profile', locals: { shuffled_overviews_on_profile: @shuffled_overviews_on_profile } %>
+        <%= render partial: 'users/related_movies/related_movie_list_on_profile', locals: { movies_data: @movies_data } %>
     </div>
   </div>
 </div>
@@ -193,12 +229,7 @@
 
 /* 既存のスタイルはそのまま */
 .tab-content {
-  display: none; /* 初期状態では非表示 */
   min-height: 550px;
-}
-
-.tab-content.active {
-  display: block; /* アクティブなコンテンツを表示 */
 }
 
 /* 他のスタイル */

--- a/app/views/users/mypage_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_shuffled_overviews.html.erb
@@ -36,7 +36,10 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -49,7 +52,11 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
             </div>
           </div>
         </div>
@@ -58,10 +65,13 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -70,17 +80,52 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
       </li>
     </ul>
   </div>
+
 
   <div class="tab-content active" id="my-shuffled-overviews-content">
     <div class="pagination-on-profile active">
@@ -193,12 +238,10 @@
 
 /* 既存のスタイルはそのまま */
 .tab-content {
-  display: none; /* 初期状態では非表示 */
   min-height: 550px;
 }
 
 .tab-content.active {
-  display: block; /* アクティブなコンテンツを表示 */
 }
 
 /* 他のスタイル */

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,13 @@ Rails.application.routes.draw do
     # サインアップ関連のルーティング（仮定）
   get 'signup', to: 'users#new', as: :signup
   get 'settings', to: 'users#show', as: :settings
+
   get 'mypage', to: 'users#mypage', as: :mypage
+  get 'mypage/shuffled_overviews', to: 'users#mypage_shuffled_overviews', as: :mypage_shuffled_overviews
+  get 'mypage/bookmarked_shuffled_overviews', to: 'users#mypage_bookmarked_shuffled_overviews', as: :mypage_bookmarked_shuffled_overviews
+  get 'mypage/my_movies', to: 'users#mypage_my_movies', as: :mypage_my_movies
+  get 'mypage/bookmarked_my_movies', to: 'users#mypage_bookmarked_my_movies', as: :mypage_bookmarked_my_movies
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   resource :avatar, only: [:edit, :update]


### PR DESCRIPTION
## GitHub Issue Ticket

- close #156 

## やった事
`このプルリクエストにて何をしたのか？`
マイページヘッダーで選択した項目によりフロントの`.active`でマイページの表示項目を切り替えていたのを
Railsのルーティングにより切り替えるように変更

クラスセレクタ.activeによる表示切替に関するjsコードも削除

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
フロントのクラスセレクタ`.active`により表示項目を切り替える利点が現状それほどないため
（SPA実装しているわけでもない）

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
テストを別途作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
