### PR TITLE
Feature 2024.09.14.23.00 マイページ内容をcurrent userのみの内容から他のユーザーの内容も実装する #162

### DIFF
--- a/app/controllers/avatars_controller.rb
+++ b/app/controllers/avatars_controller.rb
@@ -10,7 +10,7 @@ class AvatarsController < ApplicationController
     @user = current_user
 
     if @user.update(user_params)
-      redirect_to mypage_path, notice: 'アバターが更新されました。'
+      redirect_to mypage_user_path, notice: 'アバターが更新されました。'
     else
       render :edit
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,7 +38,7 @@ class UsersController < ApplicationController
   end
 
   def mypage
-    @shuffled_overviews_on_profile = current_user.shuffled_overviews.page(params[:shuffled_overviews_page]).per(5)
+    @shuffled_overviews_on_profile = @user.shuffled_overviews.page(params[:shuffled_overviews_page]).per(5)
 
     tmdb_service = TmdbService.new
     @movies_data = {}
@@ -52,10 +52,15 @@ class UsersController < ApplicationController
     end
     @movies_array = @movies_data.values
     @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
+
+    @notifications_on_mypage = @user.passive_notifications.page(params[:notifications_page]).per(20)
+    @notifications_on_mypage.where(checked: false).each do |notification|
+      notification.update(checked: true)
+    end
   end
 
   def mypage_shuffled_overviews
-    @shuffled_overviews_on_profile = current_user.shuffled_overviews.page(params[:shuffled_overviews_page]).per(5)
+    @shuffled_overviews_on_profile = @user.shuffled_overviews.page(params[:shuffled_overviews_page]).per(5)
 
     tmdb_service = TmdbService.new
     @movies_data = {}
@@ -74,7 +79,7 @@ class UsersController < ApplicationController
 
   def mypage_bookmarked_shuffled_overviews
     # Bookmarked ShuffledOverviewsのIDを取得
-    bookmarked_shuffled_overview_ids = current_user.bookmarked_shuffled_overviews.pluck(:shuffled_overview_id)
+    bookmarked_shuffled_overview_ids = @user.bookmarked_shuffled_overviews.pluck(:shuffled_overview_id)
 
     # そのIDに基づいてShuffledOverviewを取得し、ページネーションを適用
     @bookmarked_shuffled_overviews_on_profile = ShuffledOverview.where(id: bookmarked_shuffled_overview_ids).page(params[:bookmarked_shuffled_overviews_page]).per(5)
@@ -98,7 +103,7 @@ class UsersController < ApplicationController
     @movies_data = {}
 
     # ユニークな movie_id を取得する
-    unique_movie_ids = current_user.shuffled_overviews.flat_map(&:related_movie_ids).uniq
+    unique_movie_ids = @user.shuffled_overviews.flat_map(&:related_movie_ids).uniq
 
     # ユニークな movie_id を使って映画の詳細をフェッチ
     unique_movie_ids.each do |movie_id|
@@ -113,13 +118,26 @@ class UsersController < ApplicationController
     
     @bookmarked_movies_data = {}
     
-    current_user.bookmarked_movies.each do |movie|
+    @user.bookmarked_movies.each do |movie|
       tmdb_id = movie.tmdb_id
       @bookmarked_movies_data[tmdb_id] ||= tmdb_service.fetch_movie_details(tmdb_id)
     end
     
     @movies_array = @bookmarked_movies_data.values
     @paginated_movies = Kaminari.paginate_array(@movies_array).page(params[:movies_page]).per(12)
+  end
+
+  def mypage_notifications
+    @notifications_on_mypage = @user.passive_notifications.page(params[:notifications_page]).per(20)
+    @notifications_on_mypage.where(checked: false).each do |notification|
+      notification.update(checked: true)
+    end
+  end
+
+  def mark_as_read
+    notification = @user.notifications.find(params[:id])
+    notification.update(read: true)
+    redirect_to notifications_path
   end
 
   def movie_poster_path(tmdb_id)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,12 +11,12 @@
     </div>
     <div class="user-info">
       <% if current_user.avatar? %>
-        <%= link_to mypage_path, class:"header-link-of-shuffled-overview" do %>
+        <%= link_to mypage_user_path(current_user), class:"header-link-of-shuffled-overview" do %>
           <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
           <div class="user-name-on-header"><%= current_user.name %></div>
         <% end %>
       <% else %>
-        <%= link_to mypage_path, class:"header-link-of-shuffled-overview" do %>
+        <%= link_to mypage_user_path(current_user), class:"header-link-of-shuffled-overview" do %>
           <i class="fa fa-user-circle fa-2x"></i>
           <div class="user-name-on-header"><%= current_user.name %></div>
         <% end %>

--- a/app/views/layouts/_header_navibar.html.erb
+++ b/app/views/layouts/_header_navibar.html.erb
@@ -9,7 +9,7 @@
         </button>
 
         <ul>
-        <li><%= link_to 'マイページ', mypage_path %></li>
+        <li><%= link_to 'マイページ', mypage_user_path(current_user) %></li>
         <li><%= link_to '設定', settings_path %></li>
         <li><%= link_to 'タイムライン', timeline_path %></li>
         <li><%= link_to '作成したあらすじ', shuffled_overviews_path %></li>

--- a/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list_on_profile.html.erb
+++ b/app/views/users/bookmark_of_shuffled_overviews/_bookmarked_shuffled_overview_list_on_profile.html.erb
@@ -5,7 +5,7 @@
         <div class="shuffled-overview-header">
             <div class="author-info">
             <% if shuffled_overview.user.avatar? %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <%= image_tag shuffled_overview.user.avatar.url, class: 'user-avatar' %>
                   <% if shuffled_overview.user != current_user %>
@@ -20,7 +20,7 @@
                 </div>
               <% end %>
             <% else %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <i class="fa fa-user-circle fa-4x"></i>
                   <% if shuffled_overview.user != current_user %>

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -36,7 +36,10 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path(@user), class: "header-selection-wrapper tab-link active" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -49,7 +52,11 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path(@user), class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
             </div>
           </div>
         </div>
@@ -58,10 +65,13 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-              <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_user_path(@user), class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
           </div>
         </div>
@@ -70,17 +80,52 @@
         <div class="bookmarked-shuffled-overview-list">
           <div class="bookmarked-shuffled-overview-list-title-on-profile">
             <div class="header-selection-wrapper">
-              <i class="fas fa-2x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
               <i class="fas fa-heart"></i>
             </div>
             <div>
-              <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path(@user), class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
             </div>
           </div>
         </div>
       </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path(@user), class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+        <li>
+          <div class="bookmarked-shuffled-overview-list">
+            <div class="bookmarked-shuffled-overview-list-title-on-profile">
+              <div class="header-selection-wrapper">
+                <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+              </div>
+              <div>
+                <%= link_to '通知', mypage_notifications_user_path(@user), class: "header-selection-wrapper tab-link" %>
+              </div>
+              <div class="header-selection-wrapper">
+                <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+              </div>
+            </div>
+          </div>
+        </li>
     </ul>
   </div>
+
 
   <div class="tab-content active" id="my-shuffled-overviews-content">
     <div class="pagination-on-profile active">

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -1,18 +1,18 @@
 <div class="profile">
   <div class="user-info-on-profile">
-  <% if current_user.avatar? %>
+  <% if @user.avatar? %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
-        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% else %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
         <i class="fa fa-user-circle fa-2x"></i>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% end %>
   </div>
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= current_user.following.count %>
+    フォロー：<%= @user.following.count %>
     </div>
     <div>
-    フォロワー：<%= current_user.followers.count %>
+    フォロワー：<%= @user.followers.count %>
     </div>
   </div>
 

--- a/app/views/users/mypage_bookmarked_my_movies.html.erb
+++ b/app/views/users/mypage_bookmarked_my_movies.html.erb
@@ -36,7 +36,7 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -52,7 +52,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -68,7 +68,7 @@
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -84,7 +84,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link active" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -100,7 +100,7 @@
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
@@ -115,7 +115,7 @@
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '通知', mypage_notifications_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>

--- a/app/views/users/mypage_bookmarked_my_movies.html.erb
+++ b/app/views/users/mypage_bookmarked_my_movies.html.erb
@@ -1,18 +1,18 @@
 <div class="profile">
   <div class="user-info-on-profile">
-  <% if current_user.avatar? %>
+  <% if @user.avatar? %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
-        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% else %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
         <i class="fa fa-user-circle fa-2x"></i>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% end %>
   </div>
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= current_user.following.count %>
+    フォロー：<%= @user.following.count %>
     </div>
     <div>
-    フォロワー：<%= current_user.followers.count %>
+    フォロワー：<%= @user.followers.count %>
     </div>
   </div>
 

--- a/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
@@ -36,7 +36,7 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -52,7 +52,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link active" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -68,7 +68,7 @@
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -84,7 +84,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -100,7 +100,7 @@
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
@@ -115,7 +115,7 @@
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '通知', mypage_notifications_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>

--- a/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
@@ -1,18 +1,18 @@
 <div class="profile">
   <div class="user-info-on-profile">
-  <% if current_user.avatar? %>
+  <% if @user.avatar? %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
-        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% else %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
         <i class="fa fa-user-circle fa-2x"></i>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% end %>
   </div>
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= current_user.following.count %>
+    フォロー：<%= @user.following.count %>
     </div>
     <div>
-    フォロワー：<%= current_user.followers.count %>
+    フォロワー：<%= @user.followers.count %>
     </div>
   </div>
 

--- a/app/views/users/mypage_my_movies.html.erb
+++ b/app/views/users/mypage_my_movies.html.erb
@@ -1,18 +1,18 @@
 <div class="profile">
   <div class="user-info-on-profile">
-  <% if current_user.avatar? %>
+  <% if @user.avatar? %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
-        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% else %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
         <i class="fa fa-user-circle fa-2x"></i>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% end %>
   </div>
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= current_user.following.count %>
+    フォロー：<%= @user.following.count %>
     </div>
     <div>
-    フォロワー：<%= current_user.followers.count %>
+    フォロワー：<%= @user.followers.count %>
     </div>
   </div>
 

--- a/app/views/users/mypage_my_movies.html.erb
+++ b/app/views/users/mypage_my_movies.html.erb
@@ -36,7 +36,7 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -52,7 +52,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -68,7 +68,7 @@
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to '映画一覧', mypage_my_movies_user_path, class: "header-selection-wrapper tab-link active" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -84,7 +84,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -100,7 +100,7 @@
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
@@ -115,7 +115,7 @@
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '通知', mypage_notifications_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>

--- a/app/views/users/mypage_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_shuffled_overviews.html.erb
@@ -36,7 +36,7 @@
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_path, class: "header-selection-wrapper tab-link active" %>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link active" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -52,7 +52,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-book-open" style="color: #2c4c64;"></i>
@@ -68,7 +68,7 @@
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '映画一覧', mypage_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '映画一覧', mypage_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -84,7 +84,7 @@
               <i class="fas fa-heart"></i>
             </div>
             <div>
-            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
@@ -100,7 +100,7 @@
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '実績', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
@@ -115,7 +115,7 @@
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
             </div>
             <div>
-            <%= link_to '通知', mypage_bookmarked_my_movies_path, class: "header-selection-wrapper tab-link" %>
+              <%= link_to '通知', mypage_notifications_user_path, class: "header-selection-wrapper tab-link" %>
             </div>
             <div class="header-selection-wrapper">
               <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>

--- a/app/views/users/mypage_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_shuffled_overviews.html.erb
@@ -1,18 +1,18 @@
 <div class="profile">
   <div class="user-info-on-profile">
-  <% if current_user.avatar? %>
+  <% if @user.avatar? %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
-        <%= image_tag current_user.avatar.url, class: 'user-avatar' %>
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% else %>
     <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
       <div class="user-avatar-wrapper">
         <i class="fa fa-user-circle fa-2x"></i>
       </div>
-      <div class="user-name"><%= current_user.name %></div>
+      <div class="user-name"><%= @user.name %></div>
     <% end %>
   <% end %>
   </div>
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= current_user.following.count %>
+    フォロー：<%= @user.following.count %>
     </div>
     <div>
-    フォロワー：<%= current_user.followers.count %>
+    フォロワー：<%= @user.followers.count %>
     </div>
   </div>
 

--- a/app/views/users/related_movies/_related_movie_list_on_timeline.html.erb
+++ b/app/views/users/related_movies/_related_movie_list_on_timeline.html.erb
@@ -2,7 +2,7 @@
   <% @movies_data.each do |movie_id, movie_data| %>
     <div class="related-movie-image-wrapper">
       <div class="user-avatar">
-        <%= link_to mypage_path(movie_data[:user]) do %>
+        <%= link_to mypage_user_path(movie_data[:user]) do %>
           <%= image_tag movie_data[:user].avatar_url, alt: "User Avatar", class: "avatar-image-on-movie" %>
         <% end %>
       </div>

--- a/app/views/users/shuffled_overviews/_shuffled_overview_list.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overview_list.html.erb
@@ -5,7 +5,7 @@
         <div class="shuffled-overview-header">
             <div class="author-info">
             <% if shuffled_overview.user.avatar? %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <%= image_tag shuffled_overview.user.avatar.url, class: 'user-avatar' %>
                   <% if shuffled_overview.user != current_user %>
@@ -20,7 +20,7 @@
                 </div>
               <% end %>
             <% else %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <i class="fa fa-user-circle fa-4x"></i>
                   <% if shuffled_overview.user != current_user %>

--- a/app/views/users/shuffled_overviews/_shuffled_overview_list_on_profile.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overview_list_on_profile.html.erb
@@ -5,7 +5,7 @@
         <div class="shuffled-overview-header">
             <div class="author-info">
             <% if shuffled_overview.user.avatar? %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <%= image_tag shuffled_overview.user.avatar.url, class: 'user-avatar' %>
                   <% if shuffled_overview.user != current_user %>
@@ -20,7 +20,7 @@
                 </div>
               <% end %>
             <% else %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <i class="fa fa-user-circle fa-4x"></i>
                   <% if shuffled_overview.user != current_user %>

--- a/app/views/users/shuffled_overviews/_shuffled_overview_list_on_timeline.html.erb
+++ b/app/views/users/shuffled_overviews/_shuffled_overview_list_on_timeline.html.erb
@@ -5,7 +5,7 @@
         <div class="shuffled-overview-header">
           <div class="author-info">
             <% if shuffled_overview.user.avatar? %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <%= image_tag shuffled_overview.user.avatar.url, class: 'user-avatar' %>
                   <% if shuffled_overview.user != current_user %>
@@ -20,7 +20,7 @@
                 </div>
               <% end %>
             <% else %>
-              <%= link_to mypage_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
+              <%= link_to mypage_user_path(shuffled_overview.user), class: "header-link-of-shuffled-overview" do %>
                 <div class="user-avatar-wrapper">
                   <i class="fa fa-user-circle fa-4x"></i>
                   <% if shuffled_overview.user != current_user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,11 +15,16 @@ Rails.application.routes.draw do
   get 'signup', to: 'users#new', as: :signup
   get 'settings', to: 'users#show', as: :settings
 
-  get 'mypage', to: 'users#mypage', as: :mypage
-  get 'mypage/shuffled_overviews', to: 'users#mypage_shuffled_overviews', as: :mypage_shuffled_overviews
-  get 'mypage/bookmarked_shuffled_overviews', to: 'users#mypage_bookmarked_shuffled_overviews', as: :mypage_bookmarked_shuffled_overviews
-  get 'mypage/my_movies', to: 'users#mypage_my_movies', as: :mypage_my_movies
-  get 'mypage/bookmarked_my_movies', to: 'users#mypage_bookmarked_my_movies', as: :mypage_bookmarked_my_movies
+  resources :users, param: :user_id do
+    member do
+      get 'mypage', to: 'users#mypage', as: :mypage
+      get 'mypage/shuffled_overviews', to: 'users#mypage_shuffled_overviews', as: :mypage_shuffled_overviews
+      get 'mypage/bookmarked_shuffled_overviews', to: 'users#mypage_bookmarked_shuffled_overviews', as: :mypage_bookmarked_shuffled_overviews
+      get 'mypage/my_movies', to: 'users#mypage_my_movies', as: :mypage_my_movies
+      get 'mypage/bookmarked_my_movies', to: 'users#mypage_bookmarked_my_movies', as: :mypage_bookmarked_my_movies
+      get 'mypage/notifications', to: 'users#mypage_notifications', as: :mypage_notifications
+    end
+  end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -75,7 +80,7 @@ Rails.application.routes.draw do
     resources :movies, only: [:show] do
       post 'bookmark', to: 'bookmark_of_movies#bookmark', as: :bookmark_movie
       delete 'unbookmark', to: 'bookmark_of_movies#unbookmark', as: :unbookmark_movie
-     end
+    end
   end
   
   


### PR DESCRIPTION
## GitHub Issue Ticket
- close #162 

## やった事
`このプルリクエストにて何をしたのか？`
マイページにcurrent_userのみの内容しか表示できていないかったのを
params[:user_id]によりcurrent_user以外のユーザーの内容も表示するようにした

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
通知機能の実装で、他のユーザーのマイページリンクを含めて通知するようにしたいため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
テスト別途作成予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
