### PR TITLE
Feature 2024.09.15.19.21 マイページにフォロワー・フォロー一覧画面への導線リンクを追加する #170

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,7 +1,21 @@
 class FollowsController < ApplicationController
+  before_action :set_user, only: [
+    "index_followings",
+    "index_followers",
+  ]
+
+  def index_followings
+    @followings = @user.following.page(params[:followings_page]).per(10)
+  end
+
+  def index_followers
+    @followers = @user.followers.page(params[:followers_page]).per(10)
+  end
+
   def create
     @user = User.find(params[:followed_id])
     current_user.follow(@user)
+    @user.create_notification_follow!(current_user)
     respond_to do |format|
       format.html { redirect_to @user }
       format.js   # JavaScriptリクエストに対してJavaScriptを返す
@@ -15,5 +29,15 @@ class FollowsController < ApplicationController
       format.html { redirect_to @user }
       format.js   # JavaScriptリクエストに対してJavaScriptを返す
     end
+  end
+end
+
+private
+
+def set_user
+  if params[:user_id]
+    @user = User.friendly.find(params[:user_id])
+  else
+    @user = current_user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -178,9 +178,9 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :profile_sentence)
   end
-
+  
   def password_params
     params.require(:user).permit(:password, :password_confirmation)
   end

--- a/app/views/follows/_follow_formal_button.html.erb
+++ b/app/views/follows/_follow_formal_button.html.erb
@@ -1,0 +1,12 @@
+<%= link_to 'フォローする' follows_path(followed_id: user.id), method: :post, remote: true, class: 'btn follow-button' do %>
+<% end %>
+
+<style>
+.follow-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color:  black;
+  cursor: pointer;
+}
+</style>

--- a/app/views/follows/_follower_list_on_mypage.html.erb
+++ b/app/views/follows/_follower_list_on_mypage.html.erb
@@ -1,0 +1,247 @@
+<div class="content">
+  <div class="shuffled-overview-list">
+    <% @followers.each do |follower| %>
+      <div class="shuffled-overview-item">
+        <div class="shuffled-overview-header">
+            <div class="author-info">
+            <% if follower.avatar? %>
+              <%= link_to mypage_user_path(follower), class: "header-link-of-shuffled-overview" do %>
+                <div class="follower-avatar-wrapper">
+                  <%= image_tag follower.avatar.url, class: 'user-avatar' %>
+                  <% if follower != current_user %>
+                    <div id="<%= follower.id %>-follow-button-container" class="follow-button-container">
+                      <% if current_user.following?(follower) %>
+                        <%= render partial: 'follows/unfollow_button', locals: { user: follower } %>
+                      <% else %>
+                        <%= render partial: 'follows/follow_button', locals: { user: follower } %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                  <div class="follower-name">
+                    <%= follower.name %>
+                  </div>
+                </div>
+              <% end %>
+            <% else %>
+              <%= link_to mypage_user_path(follower), class: "header-link-of-shuffled-overview" do %>
+                <div class="follower-avatar-wrapper">
+                  <i class="fa fa-user-circle fa-4x"></i>
+                  <% if follower != current_user %>
+                    <div id="<%= follower.id %>-follow-button-container" class="follow-button-container">
+                      <% if current_user.following?(follower) %>
+                        <%= render partial: 'follows/unfollow_button', locals: { user: follower } %>
+                      <% else %>
+                        <%= render partial: 'follows/follow_button', locals: { user: follower } %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                  <div class="follower-name">
+                    <%= follower.name %>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="follower-content">
+          <%= truncate(follower.profile_sentence, length: 100, omission: '...') %>
+        </div>
+        <div>
+          <% if follower != current_user %>
+            <div id="<%= follower.id %>-follow-button-container" class="follow-formal-button-container">
+              <% if current_user.following?(follower) %>
+                <%= render partial: 'follows/unfollow_formal_button', locals: { user: follower } %>
+              <% else %>
+                <%= render partial: 'follows/follow_formal_button', locals: { user: follower } %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+      
+<style>
+.follow-formal-button-container {
+  border: none;
+  background-color: #ffb5b5;
+  cursor: pointer;
+  position: relative;
+  top: 15px;
+  left: 400%;
+}
+
+.follower-name {
+  font-size: 16px;
+  margin-left: 20px;
+}
+
+.follower-avatar-wrapper {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+  align-items: center;
+}
+
+.user-avatar {
+  display: block;
+  max-width: 100px; /* アイコンの最大幅 */
+  border-radius: 50%; /* アイコンを丸くする */
+}
+
+.follow-button-container {
+  position: absolute;
+  bottom: -15px; /* アイコンの下部からの距離 */
+  right: -5px; /* アイコンの右部からの距離 */
+  z-index: 10; /* アイコンの上に表示するため */
+}
+
+
+.author-info {
+  margin-bottom: 10px;
+  font-size: 14px;
+  color: #555;
+  margin-right: 10px;
+}
+
+.author-avatar {
+  max-width: 50px;
+  border-radius: 50%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh; /* ビューポートの高さに合わせる */
+}
+
+.shuffled-overview-list {
+  display: flex;
+  flex-direction: column;
+  width: 95%;
+  height: 100%;
+  box-sizing: border-box;
+  margin-top: 10px;
+}
+
+
+.shuffled-overview-item {
+  position: relative; 
+  display: flex; /* 横並びにする */
+  align-items: flex-start; /* 上揃え */
+  margin-bottom: 20px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+  padding: 20px;
+  width: 100%; /* 横幅を100%にして、親コンテナ内での幅を調整 */
+  box-sizing: border-box;
+}
+
+.link-icon-to-shuffled-overview-show {
+  position: absolute;
+  top: 10px; /* Adjust as needed to place the icon slightly away from the top */
+  right: 10px; /* Adjust as needed to place the icon slightly away from the right */
+  font-size: 18px; /* Adjust the size of the icon as needed */
+  cursor: pointer;
+}
+
+.link-icon-to-shuffled-overview-show i {
+  display: block;
+  color: #333; /* Change the color to match your design */
+}
+
+.movie-images-container {
+  display: flex;
+  flex-direction: column; /* 画像を縦に並べる */
+  margin-right: 20px; /* あらすじとの間隔を調整 */
+  position: relative; /* 相対位置に設定 */
+}
+
+.movie-images-on-profile {
+  display: flex; /* 画像を横並びにする */
+  flex-direction: row; /* 画像を縦に並べる */
+  gap: 10px; /* 画像間の間隔 */
+}
+
+.movie-image-wrapper {
+  position: relative; /* 子要素の絶対位置に基づく */
+}
+
+.movie-images img {
+  max-width: 100px; /* 画像の幅を制限 */
+  max-height: 150px; /* 画像の高さを制限 */
+  object-fit: cover; /* 画像が領域に収まるように調整 */
+}
+
+.movie-bookmark-button-container {
+  position: absolute; /* 絶対位置に設定 */
+  bottom: 10px; /* 画像の下部に位置 */
+  right: 10px; /* 画像の右部に位置 */
+  display: flex;
+  gap: 10px; /* ボタン間の間隔 */
+}
+
+.follower-content {
+  font-size: 16px;
+  margin-bottom: 10px;
+  position: relative;
+  top: 15px;
+  left: 100px;
+  color: black;
+}
+
+.shuffled-overview-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.button-container {
+  text-align: center;
+  gap: 10px;
+}
+
+.movie-link {
+  text-decoration: none;
+  color: black;
+}
+
+.pagination-on-profile {
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const readMoreLinks = document.querySelectorAll('.read-more-button');
+
+  readMoreLinks.forEach(function(link) {
+    link.addEventListener('click', function(event) {
+      event.preventDefault();
+
+      const overviewId = event.currentTarget.dataset.id;
+      const contentElement = document.getElementById(`shuffled-overview-content-${overviewId}`);
+      const fullContentElement = document.getElementById(`full-content-${overviewId}`);
+
+      if (contentElement && fullContentElement) {
+        const fullContent = fullContentElement.innerHTML;
+
+        // 切り詰められたコンテンツを完全なコンテンツに置き換える
+        contentElement.innerHTML = fullContent;
+
+        // 必要に応じて、「もっと見る」ボタンを削除または非表示にする
+        event.currentTarget.style.display = 'none';
+      } else {
+        console.error('Content element or full content element not found');
+      }
+    });
+  });
+});
+
+</script>

--- a/app/views/follows/_following_list_on_mypage.html.erb
+++ b/app/views/follows/_following_list_on_mypage.html.erb
@@ -1,0 +1,247 @@
+<div class="content">
+  <div class="shuffled-overview-list">
+    <% @followings.each do |following| %>
+      <div class="shuffled-overview-item">
+        <div class="shuffled-overview-header">
+            <div class="author-info">
+            <% if following.avatar? %>
+              <%= link_to mypage_user_path(following), class: "header-link-of-shuffled-overview" do %>
+                <div class="following-avatar-wrapper">
+                  <%= image_tag following.avatar.url, class: 'user-avatar' %>
+                  <% if following != current_user %>
+                    <div id="<%= following.id %>-follow-button-container" class="follow-button-container">
+                      <% if current_user.following?(following) %>
+                        <%= render partial: 'follows/unfollow_button', locals: { user: following } %>
+                      <% else %>
+                        <%= render partial: 'follows/follow_button', locals: { user: following } %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                  <div class="following-name">
+                    <%= following.name %>
+                  </div>
+                </div>
+              <% end %>
+            <% else %>
+              <%= link_to mypage_user_path(following), class: "header-link-of-shuffled-overview" do %>
+                <div class="following-avatar-wrapper">
+                  <i class="fa fa-user-circle fa-4x"></i>
+                  <% if following != current_user %>
+                    <div id="<%= following.id %>-follow-button-container" class="follow-button-container">
+                      <% if current_user.following?(following) %>
+                        <%= render partial: 'follows/unfollow_button', locals: { user: following } %>
+                      <% else %>
+                        <%= render partial: 'follows/follow_button', locals: { user: following } %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                  <div class="following-name">
+                    <%= following.name %>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="following-content">
+          <%= truncate(following.profile_sentence, length: 100, omission: '...') %>
+        </div>
+        <div>
+          <% if following != current_user %>
+            <div id="<%= following.id %>-follow-button-container" class="follow-formal-button-container">
+              <% if current_user.following?(following) %>
+                <%= render partial: 'follows/unfollow_formal_button', locals: { user: following } %>
+              <% else %>
+                <%= render partial: 'follows/follow_formal_button', locals: { user: following } %>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+      
+<style>
+.follow-formal-button-container {
+  border: none;
+  background-color: #ffb5b5;
+  cursor: pointer;
+  position: relative;
+  top: 15px;
+  left: 400%;
+}
+
+.following-name {
+  font-size: 16px;
+  margin-left: 20px;
+}
+
+.following-avatar-wrapper {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+  display: flex;
+  flex-direction: row;
+  align-content: center;
+  align-items: center;
+}
+
+.user-avatar {
+  display: block;
+  max-width: 100px; /* アイコンの最大幅 */
+  border-radius: 50%; /* アイコンを丸くする */
+}
+
+.follow-button-container {
+  position: absolute;
+  bottom: -15px; /* アイコンの下部からの距離 */
+  right: -5px; /* アイコンの右部からの距離 */
+  z-index: 10; /* アイコンの上に表示するため */
+}
+
+
+.author-info {
+  margin-bottom: 10px;
+  font-size: 14px;
+  color: #555;
+  margin-right: 10px;
+}
+
+.author-avatar {
+  max-width: 50px;
+  border-radius: 50%;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh; /* ビューポートの高さに合わせる */
+}
+
+.shuffled-overview-list {
+  display: flex;
+  flex-direction: column;
+  width: 95%;
+  height: 100%;
+  box-sizing: border-box;
+  margin-top: 10px;
+}
+
+
+.shuffled-overview-item {
+  position: relative; 
+  display: flex; /* 横並びにする */
+  align-items: flex-start; /* 上揃え */
+  margin-bottom: 20px;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  background-color: #f9f9f9;
+  padding: 20px;
+  width: 100%; /* 横幅を100%にして、親コンテナ内での幅を調整 */
+  box-sizing: border-box;
+}
+
+.link-icon-to-shuffled-overview-show {
+  position: absolute;
+  top: 10px; /* Adjust as needed to place the icon slightly away from the top */
+  right: 10px; /* Adjust as needed to place the icon slightly away from the right */
+  font-size: 18px; /* Adjust the size of the icon as needed */
+  cursor: pointer;
+}
+
+.link-icon-to-shuffled-overview-show i {
+  display: block;
+  color: #333; /* Change the color to match your design */
+}
+
+.movie-images-container {
+  display: flex;
+  flex-direction: column; /* 画像を縦に並べる */
+  margin-right: 20px; /* あらすじとの間隔を調整 */
+  position: relative; /* 相対位置に設定 */
+}
+
+.movie-images-on-profile {
+  display: flex; /* 画像を横並びにする */
+  flex-direction: row; /* 画像を縦に並べる */
+  gap: 10px; /* 画像間の間隔 */
+}
+
+.movie-image-wrapper {
+  position: relative; /* 子要素の絶対位置に基づく */
+}
+
+.movie-images img {
+  max-width: 100px; /* 画像の幅を制限 */
+  max-height: 150px; /* 画像の高さを制限 */
+  object-fit: cover; /* 画像が領域に収まるように調整 */
+}
+
+.movie-bookmark-button-container {
+  position: absolute; /* 絶対位置に設定 */
+  bottom: 10px; /* 画像の下部に位置 */
+  right: 10px; /* 画像の右部に位置 */
+  display: flex;
+  gap: 10px; /* ボタン間の間隔 */
+}
+
+.following-content {
+  font-size: 16px;
+  margin-bottom: 10px;
+  position: relative;
+  top: 15px;
+  left: 100px;
+  color: black;
+}
+
+.shuffled-overview-meta {
+  font-size: 12px;
+  color: #888;
+}
+
+.button-container {
+  text-align: center;
+  gap: 10px;
+}
+
+.movie-link {
+  text-decoration: none;
+  color: black;
+}
+
+.pagination-on-profile {
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const readMoreLinks = document.querySelectorAll('.read-more-button');
+
+  readMoreLinks.forEach(function(link) {
+    link.addEventListener('click', function(event) {
+      event.preventDefault();
+
+      const overviewId = event.currentTarget.dataset.id;
+      const contentElement = document.getElementById(`shuffled-overview-content-${overviewId}`);
+      const fullContentElement = document.getElementById(`full-content-${overviewId}`);
+
+      if (contentElement && fullContentElement) {
+        const fullContent = fullContentElement.innerHTML;
+
+        // 切り詰められたコンテンツを完全なコンテンツに置き換える
+        contentElement.innerHTML = fullContent;
+
+        // 必要に応じて、「もっと見る」ボタンを削除または非表示にする
+        event.currentTarget.style.display = 'none';
+      } else {
+        console.error('Content element or full content element not found');
+      }
+    });
+  });
+});
+
+</script>

--- a/app/views/follows/_unfollow_formal_button.html.erb
+++ b/app/views/follows/_unfollow_formal_button.html.erb
@@ -1,0 +1,10 @@
+<%= link_to 'フォローを解除する', follow_path(Follow.find_by(follower_id: current_user.id, followed_id: user.id)), method: :delete, remote: true, class: 'btn btn-primary formal-btn-unfollow' %>
+
+
+<style>
+.formal-btn-unfollow {
+  border: none;
+  background-color:  #ffb5b5;
+  cursor: pointer;
+}
+</style>

--- a/app/views/follows/index_followers.html.erb
+++ b/app/views/follows/index_followers.html.erb
@@ -1,0 +1,588 @@
+<div class="profile">
+  <div class="user-info-on-profile">
+  <% if @user.avatar? %>
+    <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
+      <div class="user-avatar-wrapper">
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
+      </div>
+      <div class="user-name"><%= @user.name %></div>
+    <% end %>
+  <% else %>
+    <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
+      <div class="user-avatar-wrapper">
+        <i class="fa fa-user-circle fa-2x"></i>
+      </div>
+      <div class="user-name"><%= @user.name %></div>
+    <% end %>
+  <% end %>
+  </div>
+
+  
+  <div class="follow-info">
+    <div>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following active" %>
+    </div>
+    <div>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers active" %>
+    </div>
+  </div>
+
+  <div class="profile-header">
+    <ul>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+            <div>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '映画一覧', mypage_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+            <div>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '通知', mypage_notifications_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+
+
+  <div class="tab-content active" id="my-movies-content">
+   <div class="pagination-on-profile active">
+      <%= paginate @followers, param_name: :followers_page %>
+    </div>
+    <div class="scroll-indicator">
+    </div>
+    <div class="profile-body">
+      <%= render partial: 'follows/follower_list_on_mypage', locals: { followers: @followers } %>
+    </div>
+  </div>
+</div>
+
+<div id="movie-info-popup" class="hidden">
+  <div id="popup-title"></div>
+  <img id="popup-image" src="" alt="Movie Image">
+</div>
+
+
+<style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  background-color: #D3DEF1;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+/* Kaminari カスタムスタイル */
+
+/* 全体のスタイル */
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+  list-style: none;
+  padding: 0;
+  text-decoration: none;
+}
+
+.pagination a {
+  display: flex;
+  text-decoration: none;
+  justify-content: center;
+  color: black;
+}
+
+/* ページリンクのスタイル */
+.pagination .page {
+  margin: 0 5px;
+  padding: 10px 15px;
+  text-decoration: none;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  color: #333;
+  background-color: #f9f9f9;
+}
+
+/* 現在のページのスタイル */
+.pagination .current {
+  background-color: #007bff;
+  color: #fff;
+  border: 1px solid #007bff;
+  font-weight: bold;
+}
+
+/* 無効なリンクのスタイル */
+.pagination .disabled {
+  color: #aaa;
+  border: 1px solid #ddd;
+  background-color: #f9f9f9;
+}
+
+/* その他のリンクのスタイル */
+.pagination .first,
+.pagination .last,
+.pagination .prev,
+.pagination .next {
+  background-color: #f1f1f1;
+  width: 40px;
+  border-radius: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pagination .first:hover,
+.pagination .last:hover,
+.pagination .prev:hover,
+.pagination .next:hover {
+  background-color: #e1e1e1;
+}
+
+.tab-link.active {
+  position: relative; /* 擬似要素のために必要 */
+  color: black; /* リンクの色 */
+}
+
+.tab-link.active::after {
+  content: "";
+  position: absolute;
+  bottom: 0; /* リンクの下部に配置 */
+  left: 0;
+  width: 100%;
+  height: 2px; /* ボーダーの高さ */
+  background-color: blue; /* 青線の色 */
+  border-radius: 0; /* ボーダーの丸みをなくす */
+  z-index: 1; /* ボーダーがリンクの下に表示されないように */
+}
+
+/* 既存のスタイルはそのまま */
+.tab-content {
+  min-height: 550px;
+}
+
+/* 他のスタイル */
+.bookmarked-shuffled-overview-list {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column; /* 縦並びにする */
+  width: 100%; /* 横幅を調整 */
+  box-sizing: border-box;
+}
+
+.bookmarked-shuffled-overview-list-title-on-profile {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.header-selection-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  color: black;
+
+  .fa-heart {
+    color: red; /* アイコンの色を赤に変更（任意） */
+    font-size: 14px; /* アイコンのサイズを調整（任意） */
+    vertical-align: middle; /* テキストとアイコンを垂直方向に中央揃え */
+  }
+}
+
+.profile {
+  position: relative; /* 絶対配置から相対配置に変更 */
+  top: 20px;
+  left: 10px;
+  width: calc(100%); /* 画面幅いっぱいに広げる（左マージンの10px分を考慮） */
+//  overflow-y: auto;
+  padding-bottom: 100px;
+}
+
+.user-info-on-profile {
+  z-index: ;
+  display: flex;
+  justify-content: space-between; /* アバターとフォロー情報を左右に配置 */
+  align-items: center;
+}
+
+.follow-info {
+  display: flex;
+  flex-direction: row;
+  text-align: right;
+  position: absolute;
+  top: 0;
+  right: 30px;
+  gap: 30px;
+}
+
+.user-avatar-on-profile {
+  display: flex;
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.user-avatar-wrapper {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+}
+
+.user-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.user-name {
+  font-size: 1.5rem;
+}
+
+.profile-contents {
+  margin-top: 20px;
+}
+
+.profile-header {
+  position: relative;
+  width: 100%;
+  background-color: #f8f8f8;
+  box-sizing: border-box;
+  top: -20px;
+}
+
+.profile-header ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  justify-content: flex-start;
+  gap: 75px;
+  margin-left: 50px;
+  align-items: center;
+}
+
+.profile-header li {
+  font-size: 1.2rem;
+}
+
+.profile-header a {
+  text-decoration: none;
+  color: black;
+  border-radius: 20px; /* 丸みを帯びたボタン風 */
+  position: relative; /* 擬似要素の位置を調整するために必要 */
+  transition: background-color 0.3s ease;
+}
+
+.profile-header a.active::after {
+  content: "";
+  position: absolute;
+  bottom: -2px; /* ボーダーをリンクの下に配置 */
+  left: 0;
+  width: 100%;
+  height: 6px; /* ボーダーの高さ */
+  background: rgba(0, 0, 255, 0.5); /* グレーの蛍光ペン風の色 */
+  box-shadow: 0 0 4px rgba(0, 0, 255, 0.2); /* 蛍光ペン風の影 */
+  border-radius: 0; /* 丸みをなくす */
+}
+
+.profile-header a:hover {
+  background-color: #f0f0f0; /* ホバー時の背景色変更 */
+}
+
+.profile-body {
+  position: relative; /* Ensure the profile-body is the reference point for absolute positioning */
+  border: 1px solid #ccc; /* Example border for visual reference */
+  /* Other styles */
+  overflow: auto; /* または scroll */
+  height: 100%; /* 定義された高さが必要です */
+}
+
+.scroll-downforward-indicator {
+  position: absolute;
+  width: 40px; /* Width and height for the circular indicators */
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(128, 128, 128, 0.4); /* Semi-transparent background */
+  border: 1px solid #ccc; /* Border color */
+  border-radius: 50%; /* Round shape */
+  cursor: pointer; /* Pointer cursor on hover */
+  top: 140px; /* Position from the top edge */
+  right: 100px; /* Position from the right edge */
+  z-index: 5;
+}
+
+.scroll-upforward-indicator {
+  position: absolute;
+  width: 40px; /* Width and height for the circular indicators */
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(128, 128, 128, 0.4); /* Semi-transparent background */
+  border: 1px solid #ccc; /* Border color */
+  border-radius: 50%; /* Round shape */
+  cursor: pointer; /* Pointer cursor on hover */
+  top: 140px; /* Position from the top edge */
+  right: 50px; /* Position from the right edge */
+  z-index: 5;
+}
+
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
+.scroll-indicator-icon {
+  font-size: 20px; /* Adjust icon size */
+}
+
+.hidden {
+  display: none; /* Hide the indicator initially */
+}
+
+
+#movie-info-popup {
+  position: absolute;
+  display: none;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+  z-index: 1000;
+  max-width: 300px;
+  max-height: 200px;
+  overflow: hidden;
+}
+
+#popup-image {
+  max-width: 100%;
+  max-height: 150px;
+  display: block;
+}
+
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  // Movie info popup
+  const popup = document.getElementById('movie-info-popup');
+  const popupTitle = document.getElementById('popup-title');
+  const popupImage = document.getElementById('popup-image');
+
+  function enableLinksAndHoverEvents() {
+    document.querySelectorAll('.movie-link').forEach(link => {
+      link.addEventListener('mouseover', (event) => {
+        const movieInfo = event.target.dataset.movieInfo;
+        const movieImage = event.target.dataset.movieImage;
+        popupTitle.textContent = movieInfo;
+        popupImage.src = movieImage;
+
+        popup.style.display = 'block';
+
+        let top = event.clientY + window.scrollY + 10;
+        let left = event.clientX + window.scrollX + 10;
+
+        const popupWidth = popup.offsetWidth;
+        const popupHeight = popup.offsetHeight;
+
+        if (left + popupWidth > window.innerWidth + window.scrollX) {
+          left = window.innerWidth + window.scrollX - popupWidth - 10;
+        }
+
+        if (top + popupHeight > window.innerHeight + window.scrollY) {
+          top = window.innerHeight + window.scrollY - popupHeight - 10;
+        }
+
+        popup.style.top = `${top}px`;
+        popup.style.left = `${left}px`;
+      });
+
+      link.addEventListener('mouseout', () => {
+        popup.style.display = 'none';
+      });
+    });
+  }
+
+  function attachEventListeners() {
+    enableLinksAndHoverEvents();
+    document.querySelectorAll('.read-aloud-button').forEach(button => {
+      button.addEventListener('click', (event) => {
+        const container = event.target.closest('.shuffled-overview-item').querySelector('.shuffled-overview-content');
+        readAloud(container.textContent);
+      });
+    });
+
+    document.querySelectorAll('.stop-button').forEach(button => {
+      button.addEventListener('click', stopReading);
+    });
+  }
+
+  attachEventListeners(); // 初期のDOMContentLoaded時のイベントリスナーの設定
+
+  async function getVoices() {
+    return new Promise(resolve => {
+      let synth = window.speechSynthesis;
+      let id;
+
+      id = setInterval(() => {
+        if (synth.getVoices().length !== 0) {
+          resolve(synth.getVoices());
+          clearInterval(id);
+        }
+      }, 10);
+    });
+  }
+
+  let voices = [];
+
+  async function readAloud(text) {
+    if (voices.length === 0) {
+      voices = await getVoices();
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'ja-JP';
+
+    const voiceName = 'Kyoko';
+    const voice = voices.find(v => v.name.includes(voiceName)) || voices[0];
+    utterance.voice = voice;
+
+    speechSynthesis.speak(utterance);
+  }
+
+  function stopReading() {
+    speechSynthesis.cancel();
+  }
+
+  // コンテンツが動的にロードされた後にイベントリスナーを再設定
+  document.addEventListener('ajax:success', (event) => {
+    attachEventListeners();
+  });
+
+const profileBody = document.querySelector('.profile-body');
+const scrollDownforwardIndicator = document.querySelector('.scroll-downforward-indicator');
+const scrollUpforwardIndicator = document.querySelector('.scroll-upforward-indicator');
+
+function scrollProfileBody(direction) {
+  if (direction === 'down') {
+    profileBody.scrollBy({
+      top: profileBody.clientHeight, // ビューポートの高さ分スクロール
+      behavior: 'smooth'
+    });
+  } else if (direction === 'up') {
+    profileBody.scrollBy({
+      top: -profileBody.clientHeight, // ビューポートの高さ分スクロールアップ
+      behavior: 'smooth'
+    });
+  }
+}
+
+scrollDownforwardIndicator.addEventListener('click', function () {
+  scrollProfileBody('down');
+});
+
+scrollUpforwardIndicator.addEventListener('click', function () {
+  scrollProfileBody('up');
+});  
+});
+
+document.addEventListener("DOMContentLoaded", anchorKeeper);
+
+</script>

--- a/app/views/follows/index_followings.html.erb
+++ b/app/views/follows/index_followings.html.erb
@@ -1,0 +1,588 @@
+<div class="profile">
+  <div class="user-info-on-profile">
+  <% if @user.avatar? %>
+    <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
+      <div class="user-avatar-wrapper">
+        <%= image_tag @user.avatar.url, class: 'user-avatar' %>
+      </div>
+      <div class="user-name"><%= @user.name %></div>
+    <% end %>
+  <% else %>
+    <%= link_to edit_avatar_path, class:"user-avatar-on-profile" do %>
+      <div class="user-avatar-wrapper">
+        <i class="fa fa-user-circle fa-2x"></i>
+      </div>
+      <div class="user-name"><%= @user.name %></div>
+    <% end %>
+  <% end %>
+  </div>
+
+  
+  <div class="follow-info">
+    <div>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following active" %>
+    </div>
+    <div>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
+    </div>
+  </div>
+
+  <div class="profile-header">
+    <ul>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to 'あらすじ一覧', mypage_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+            <div>
+            <%= link_to 'いいね (あらすじ)', mypage_bookmarked_shuffled_overviews_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-book-open" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '映画一覧', mypage_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+            <div>
+            <%= link_to 'いいね (映画)', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-film" style="color: #2c4c64;"></i>
+              <i class="fas fa-heart"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '実績', mypage_bookmarked_my_movies_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-calendar" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+      <li>
+        <div class="bookmarked-shuffled-overview-list">
+          <div class="bookmarked-shuffled-overview-list-title-on-profile">
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+            <div>
+            <%= link_to '通知', mypage_notifications_user_path, class: "header-selection-wrapper tab-link" %>
+            </div>
+            <div class="header-selection-wrapper">
+              <i class="fas fa-1x fa-bell" style="color: #2c4c64;"></i>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </div>
+
+
+  <div class="tab-content active" id="my-movies-content">
+    <div class="pagination-on-profile">
+      <%= paginate @followings, param_name: :followings_page %>
+    </div>
+    <div class="scroll-indicator">
+    </div>
+    <div class="profile-body">
+      <%= render partial: 'follows/following_list_on_mypage', locals: { followings: @followings } %>
+    </div>
+  </div>
+</div>
+
+<div id="movie-info-popup" class="hidden">
+  <div id="popup-title"></div>
+  <img id="popup-image" src="" alt="Movie Image">
+</div>
+
+
+<style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  background-color: #D3DEF1;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+/* Kaminari カスタムスタイル */
+
+/* 全体のスタイル */
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+  list-style: none;
+  padding: 0;
+  text-decoration: none;
+}
+
+.pagination a {
+  display: flex;
+  text-decoration: none;
+  justify-content: center;
+  color: black;
+}
+
+/* ページリンクのスタイル */
+.pagination .page {
+  margin: 0 5px;
+  padding: 10px 15px;
+  text-decoration: none;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  color: #333;
+  background-color: #f9f9f9;
+}
+
+/* 現在のページのスタイル */
+.pagination .current {
+  background-color: #007bff;
+  color: #fff;
+  border: 1px solid #007bff;
+  font-weight: bold;
+}
+
+/* 無効なリンクのスタイル */
+.pagination .disabled {
+  color: #aaa;
+  border: 1px solid #ddd;
+  background-color: #f9f9f9;
+}
+
+/* その他のリンクのスタイル */
+.pagination .first,
+.pagination .last,
+.pagination .prev,
+.pagination .next {
+  background-color: #f1f1f1;
+  width: 40px;
+  border-radius: 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pagination .first:hover,
+.pagination .last:hover,
+.pagination .prev:hover,
+.pagination .next:hover {
+  background-color: #e1e1e1;
+}
+
+.tab-link.active {
+  position: relative; /* 擬似要素のために必要 */
+  color: black; /* リンクの色 */
+}
+
+.tab-link.active::after {
+  content: "";
+  position: absolute;
+  bottom: 0; /* リンクの下部に配置 */
+  left: 0;
+  width: 100%;
+  height: 2px; /* ボーダーの高さ */
+  background-color: blue; /* 青線の色 */
+  border-radius: 0; /* ボーダーの丸みをなくす */
+  z-index: 1; /* ボーダーがリンクの下に表示されないように */
+}
+
+/* 既存のスタイルはそのまま */
+.tab-content {
+  min-height: 550px;
+}
+
+/* 他のスタイル */
+.bookmarked-shuffled-overview-list {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column; /* 縦並びにする */
+  width: 100%; /* 横幅を調整 */
+  box-sizing: border-box;
+}
+
+.bookmarked-shuffled-overview-list-title-on-profile {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.header-selection-wrapper {
+  position: relative;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  text-decoration: none;
+  color: black;
+
+  .fa-heart {
+    color: red; /* アイコンの色を赤に変更（任意） */
+    font-size: 14px; /* アイコンのサイズを調整（任意） */
+    vertical-align: middle; /* テキストとアイコンを垂直方向に中央揃え */
+  }
+}
+
+.profile {
+  position: relative; /* 絶対配置から相対配置に変更 */
+  top: 20px;
+  left: 10px;
+  width: calc(100%); /* 画面幅いっぱいに広げる（左マージンの10px分を考慮） */
+//  overflow-y: auto;
+  padding-bottom: 100px;
+}
+
+.user-info-on-profile {
+  z-index: ;
+  display: flex;
+  justify-content: space-between; /* アバターとフォロー情報を左右に配置 */
+  align-items: center;
+}
+
+.follow-info {
+  display: flex;
+  flex-direction: row;
+  text-align: right;
+  position: absolute;
+  top: 0;
+  right: 30px;
+  gap: 30px;
+}
+
+.user-avatar-on-profile {
+  display: flex;
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+}
+
+.user-avatar-wrapper {
+  position: relative;
+  width: 50px;
+  height: 50px;
+  margin-right: 10px;
+}
+
+.user-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.user-name {
+  font-size: 1.5rem;
+}
+
+.profile-contents {
+  margin-top: 20px;
+}
+
+.profile-header {
+  position: relative;
+  width: 100%;
+  background-color: #f8f8f8;
+  box-sizing: border-box;
+  top: -20px;
+}
+
+.profile-header ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  justify-content: flex-start;
+  gap: 75px;
+  margin-left: 50px;
+  align-items: center;
+}
+
+.profile-header li {
+  font-size: 1.2rem;
+}
+
+.profile-header a {
+  text-decoration: none;
+  color: black;
+  border-radius: 20px; /* 丸みを帯びたボタン風 */
+  position: relative; /* 擬似要素の位置を調整するために必要 */
+  transition: background-color 0.3s ease;
+}
+
+.profile-header a.active::after {
+  content: "";
+  position: absolute;
+  bottom: -2px; /* ボーダーをリンクの下に配置 */
+  left: 0;
+  width: 100%;
+  height: 6px; /* ボーダーの高さ */
+  background: rgba(0, 0, 255, 0.5); /* グレーの蛍光ペン風の色 */
+  box-shadow: 0 0 4px rgba(0, 0, 255, 0.2); /* 蛍光ペン風の影 */
+  border-radius: 0; /* 丸みをなくす */
+}
+
+.profile-header a:hover {
+  background-color: #f0f0f0; /* ホバー時の背景色変更 */
+}
+
+.profile-body {
+  position: relative; /* Ensure the profile-body is the reference point for absolute positioning */
+  border: 1px solid #ccc; /* Example border for visual reference */
+  /* Other styles */
+  overflow: auto; /* または scroll */
+  height: 100%; /* 定義された高さが必要です */
+}
+
+.scroll-downforward-indicator {
+  position: absolute;
+  width: 40px; /* Width and height for the circular indicators */
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(128, 128, 128, 0.4); /* Semi-transparent background */
+  border: 1px solid #ccc; /* Border color */
+  border-radius: 50%; /* Round shape */
+  cursor: pointer; /* Pointer cursor on hover */
+  top: 140px; /* Position from the top edge */
+  right: 100px; /* Position from the right edge */
+  z-index: 5;
+}
+
+.scroll-upforward-indicator {
+  position: absolute;
+  width: 40px; /* Width and height for the circular indicators */
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(128, 128, 128, 0.4); /* Semi-transparent background */
+  border: 1px solid #ccc; /* Border color */
+  border-radius: 50%; /* Round shape */
+  cursor: pointer; /* Pointer cursor on hover */
+  top: 140px; /* Position from the top edge */
+  right: 50px; /* Position from the right edge */
+  z-index: 5;
+}
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
+
+.scroll-indicator-icon {
+  font-size: 20px; /* Adjust icon size */
+}
+
+.hidden {
+  display: none; /* Hide the indicator initially */
+}
+
+
+#movie-info-popup {
+  position: absolute;
+  display: none;
+  background-color: white;
+  border: 1px solid black;
+  padding: 10px;
+  z-index: 1000;
+  max-width: 300px;
+  max-height: 200px;
+  overflow: hidden;
+}
+
+#popup-image {
+  max-width: 100%;
+  max-height: 150px;
+  display: block;
+}
+
+</style>
+
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  // Movie info popup
+  const popup = document.getElementById('movie-info-popup');
+  const popupTitle = document.getElementById('popup-title');
+  const popupImage = document.getElementById('popup-image');
+
+  function enableLinksAndHoverEvents() {
+    document.querySelectorAll('.movie-link').forEach(link => {
+      link.addEventListener('mouseover', (event) => {
+        const movieInfo = event.target.dataset.movieInfo;
+        const movieImage = event.target.dataset.movieImage;
+        popupTitle.textContent = movieInfo;
+        popupImage.src = movieImage;
+
+        popup.style.display = 'block';
+
+        let top = event.clientY + window.scrollY + 10;
+        let left = event.clientX + window.scrollX + 10;
+
+        const popupWidth = popup.offsetWidth;
+        const popupHeight = popup.offsetHeight;
+
+        if (left + popupWidth > window.innerWidth + window.scrollX) {
+          left = window.innerWidth + window.scrollX - popupWidth - 10;
+        }
+
+        if (top + popupHeight > window.innerHeight + window.scrollY) {
+          top = window.innerHeight + window.scrollY - popupHeight - 10;
+        }
+
+        popup.style.top = `${top}px`;
+        popup.style.left = `${left}px`;
+      });
+
+      link.addEventListener('mouseout', () => {
+        popup.style.display = 'none';
+      });
+    });
+  }
+
+  function attachEventListeners() {
+    enableLinksAndHoverEvents();
+    document.querySelectorAll('.read-aloud-button').forEach(button => {
+      button.addEventListener('click', (event) => {
+        const container = event.target.closest('.shuffled-overview-item').querySelector('.shuffled-overview-content');
+        readAloud(container.textContent);
+      });
+    });
+
+    document.querySelectorAll('.stop-button').forEach(button => {
+      button.addEventListener('click', stopReading);
+    });
+  }
+
+  attachEventListeners(); // 初期のDOMContentLoaded時のイベントリスナーの設定
+
+  async function getVoices() {
+    return new Promise(resolve => {
+      let synth = window.speechSynthesis;
+      let id;
+
+      id = setInterval(() => {
+        if (synth.getVoices().length !== 0) {
+          resolve(synth.getVoices());
+          clearInterval(id);
+        }
+      }, 10);
+    });
+  }
+
+  let voices = [];
+
+  async function readAloud(text) {
+    if (voices.length === 0) {
+      voices = await getVoices();
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'ja-JP';
+
+    const voiceName = 'Kyoko';
+    const voice = voices.find(v => v.name.includes(voiceName)) || voices[0];
+    utterance.voice = voice;
+
+    speechSynthesis.speak(utterance);
+  }
+
+  function stopReading() {
+    speechSynthesis.cancel();
+  }
+
+  // コンテンツが動的にロードされた後にイベントリスナーを再設定
+  document.addEventListener('ajax:success', (event) => {
+    attachEventListeners();
+  });
+
+const profileBody = document.querySelector('.profile-body');
+const scrollDownforwardIndicator = document.querySelector('.scroll-downforward-indicator');
+const scrollUpforwardIndicator = document.querySelector('.scroll-upforward-indicator');
+
+function scrollProfileBody(direction) {
+  if (direction === 'down') {
+    profileBody.scrollBy({
+      top: profileBody.clientHeight, // ビューポートの高さ分スクロール
+      behavior: 'smooth'
+    });
+  } else if (direction === 'up') {
+    profileBody.scrollBy({
+      top: -profileBody.clientHeight, // ビューポートの高さ分スクロールアップ
+      behavior: 'smooth'
+    });
+  }
+}
+
+scrollDownforwardIndicator.addEventListener('click', function () {
+  scrollProfileBody('down');
+});
+
+scrollUpforwardIndicator.addEventListener('click', function () {
+  scrollProfileBody('up');
+});  
+});
+
+document.addEventListener("DOMContentLoaded", anchorKeeper);
+
+</script>

--- a/app/views/timeline/index.html.erb
+++ b/app/views/timeline/index.html.erb
@@ -391,6 +391,10 @@ select#search-genre-select {
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -417,6 +417,10 @@
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage.html.erb
+++ b/app/views/users/mypage.html.erb
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= @user.following.count %>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following" %>
     </div>
     <div>
-    フォロワー：<%= @user.followers.count %>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
     </div>
   </div>
 
@@ -154,6 +154,26 @@
 
 
 <style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
 /* Kaminari カスタムスタイル */
 
 /* 全体のスタイル */

--- a/app/views/users/mypage_bookmarked_my_movies.html.erb
+++ b/app/views/users/mypage_bookmarked_my_movies.html.erb
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= @user.following.count %>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following active" %>
     </div>
     <div>
-    フォロワー：<%= @user.followers.count %>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
     </div>
   </div>
 
@@ -144,6 +144,27 @@
 
 
 <style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+
 /* Kaminari カスタムスタイル */
 
 /* 全体のスタイル */

--- a/app/views/users/mypage_bookmarked_my_movies.html.erb
+++ b/app/views/users/mypage_bookmarked_my_movies.html.erb
@@ -405,6 +405,10 @@
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= @user.following.count %>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following" %>
     </div>
     <div>
-    フォロワー：<%= @user.followers.count %>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
     </div>
   </div>
 
@@ -154,6 +154,27 @@
 
 
 <style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+
 /* Kaminari カスタムスタイル */
 
 /* 全体のスタイル */

--- a/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_bookmarked_shuffled_overviews.html.erb
@@ -412,6 +412,10 @@
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage_my_movies.html.erb
+++ b/app/views/users/mypage_my_movies.html.erb
@@ -403,6 +403,10 @@
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage_my_movies.html.erb
+++ b/app/views/users/mypage_my_movies.html.erb
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= @user.following.count %>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following active" %>
     </div>
     <div>
-    フォロワー：<%= @user.followers.count %>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
     </div>
   </div>
 
@@ -145,6 +145,27 @@
 
 
 <style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+
 /* Kaminari カスタムスタイル */
 
 /* 全体のスタイル */

--- a/app/views/users/mypage_notifications.html.erb
+++ b/app/views/users/mypage_notifications.html.erb
@@ -429,6 +429,10 @@
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage_notifications.html.erb
+++ b/app/views/users/mypage_notifications.html.erb
@@ -17,16 +17,15 @@
   <% end %>
   </div>
 
-  
   <div class="follow-info">
     <div>
-    フォロー：<%= current_user.following.count %>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following active" %>
     </div>
     <div>
-    フォロワー：<%= current_user.followers.count %>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
     </div>
   </div>
-
+  
   <div class="profile-header">
     <ul>
       <li>
@@ -156,6 +155,27 @@
 
 
 <style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+
 .notification-badge {
   background-color: red;
   color: white;

--- a/app/views/users/mypage_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_shuffled_overviews.html.erb
@@ -415,6 +415,10 @@
   right: 50px; /* Position from the right edge */
   z-index: 5;
 }
+.scroll-indicator {
+  position: relative;
+  top: -160px;
+}
 
 .scroll-indicator-icon {
   font-size: 20px; /* Adjust icon size */

--- a/app/views/users/mypage_shuffled_overviews.html.erb
+++ b/app/views/users/mypage_shuffled_overviews.html.erb
@@ -20,10 +20,10 @@
   
   <div class="follow-info">
     <div>
-    フォロー：<%= @user.following.count %>
+      <%= link_to "フォロー：#{@user.following.count}", followings_user_path(@user), class: "link-to-index-following active" %>
     </div>
     <div>
-    フォロワー：<%= @user.followers.count %>
+      <%= link_to "フォロワー：#{@user.followers.count}", followers_user_path(@user), class: "link-to-index-followers" %>
     </div>
   </div>
 
@@ -154,6 +154,27 @@
 
 
 <style>
+.following-info {
+
+}
+.link-to-index-following {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-followers {
+  text-decoration: none;
+  color: black;
+  border-radius: 5px;
+}
+.link-to-index-following:hover {
+  background-color: #e1e1e1;
+}
+.link-to-index-followers:hover {
+  background-color: #e1e1e1;
+}
+
+
 /* Kaminari カスタムスタイル */
 
 /* 全体のスタイル */

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,10 @@ Rails.application.routes.draw do
     member do
       get 'movies/:movie_id', to: 'related_movies#show', as: :movie
     end
+    member do
+      get 'followings', to: 'follows#index_followings', as: :followings
+      get 'followers', to: 'follows#index_followers', as: :followers
+    end
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20240915112912_add_profile_sentence_to_users.rb
+++ b/db/migrate/20240915112912_add_profile_sentence_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileSentenceToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :profile_sentence, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_13_153058) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_15_112912) do
   create_table "appearance_of_characters", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "character_id", null: false
     t.bigint "shuffled_overview_id", null: false
@@ -129,6 +129,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_13_153058) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.string "avatar"
+    t.string "profile_sentence"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
## GitHub Issue Ticket
- close #170 
- close #171

## やった事
`このプルリクエストにて何をしたのか？`
 - フォロー一覧・フォロワー一覧画面の実装
 - マイページの各ページにフォロー一覧・フォロワー一覧画面への導線リンクを追加

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
フォロー数・フォロワー数の表示をしているがその詳細を見れないことに対する機能の充実化

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
別途テスト実装予定

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
