### PR TITLE
Test_2024.09.21.05.28_Keywordモデルのモデルスペック / Keywordモデルのuniquenessバリデーションを削除

### DIFF
--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,6 +1,9 @@
 class Keyword < ApplicationRecord
+  ## Validation
+  validates :content, presence: true
+  # validates :content, uniqueness: true
+
+  ## Association
   has_many :shuffled_overview_keywords
   has_many :shuffled_overviews, through: :shuffled_overview_keywords
-  
-  validates :content, presence: true, uniqueness: true
 end

--- a/spec/factories/keywords.rb
+++ b/spec/factories/keywords.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :keyword do
+    content { Faker::Lorem.unique.word } # Fakerを使ってランダムな単語を生成
+  end
+end

--- a/spec/models/keyword_spec.rb
+++ b/spec/models/keyword_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Keyword, type: :model do
+  # バリデーションのテスト
+  context 'validations' do
+    it 'is valid with valid attributes' do
+      keyword = build(:keyword) # FactoryBotを使用してkeywordを生成
+      expect(keyword).to be_valid
+    end
+
+    it 'is not valid without content' do
+      keyword = build(:keyword, content: nil) # contentをnilにして無効なkeywordを生成
+      expect(keyword).not_to be_valid
+    end
+
+    # uniqueness validation : 同じキーワードであっても違うShuffledOverviewモデルから作成されたら区別されるようにしたい
+      # it 'is not valid with duplicate content' do
+      #   create(:keyword, content: 'duplicate_content') # 重複するcontentを持つkeywordを作成
+      #   keyword = build(:keyword, content: 'duplicate_content') # 同じcontentで別のkeywordを作成
+      #   expect(keyword).not_to be_valid
+      # end
+  end
+
+  # アソシエーションのテスト
+  context 'associations' do
+    it 'has many shuffled_overview_keywords' do
+      association = described_class.reflect_on_association(:shuffled_overview_keywords)
+      expect(association.macro).to eq :has_many
+    end
+
+    it 'has many shuffled_overviews through shuffled_overview_keywords' do
+      association = described_class.reflect_on_association(:shuffled_overviews)
+      expect(association.macro).to eq :has_many
+      expect(association.options[:through]).to eq :shuffled_overview_keywords
+    end
+  end
+end


### PR DESCRIPTION
## GitHub Issue Ticket
- close #199 

## やった事
`このプルリクエストにて何をしたのか？`
 - Keywordモデルのモデルスペックを実施
```ruby
class Keyword < ApplicationRecord
  ## Validation
  validates :content, presence: true
  validates :content, uniqueness: true

  ## Association
  has_many :shuffled_overview_keywords
  has_many :shuffled_overviews, through: :shuffled_overview_keywords
end
``` 
 - Keywordモデルのvalidationを変更
```ruby
class Keyword < ApplicationRecord
  ## Validation
  validates :content, presence: true
  # validates :content, uniqueness: true 
  # 同じ:contentのKeywordモデルレコードであっても、異なるShuffledOverviewモデルレコード
``` 

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
下記コードでテスト実施、テストパスを確認
```
docker-compose run web bundle exec rspec spec/models/keyword_spec.rb
``` 

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
