### PR TITLE
Test_2024.09.21.06.46_ShuffledOverviewKeywordモデルのモデルスペック

### DIFF
--- a/app/models/shuffled_overview_keyword.rb
+++ b/app/models/shuffled_overview_keyword.rb
@@ -1,4 +1,9 @@
 class ShuffledOverviewKeyword < ApplicationRecord
+  ## validation
+  validates :keyword_id, uniqueness: { scope: :shuffled_overview_id, message: "has already been added to this shuffled overview" }
+  # 特定の ShuffledOverview に対して Keyword が一意である
+
+  ## association
   belongs_to :shuffled_overview
   belongs_to :keyword
 end

--- a/spec/factories/shuffled_overview_keywords.rb
+++ b/spec/factories/shuffled_overview_keywords.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :shuffled_overview_keyword do
+    association :shuffled_overview
+    association :keyword
+  end
+end

--- a/spec/models/shuffled_overview_keyword_spec.rb
+++ b/spec/models/shuffled_overview_keyword_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe ShuffledOverviewKeyword, type: :model do
+  let(:shuffled_overview) { create(:shuffled_overview) }
+  let(:keyword) { create(:keyword) }
+  let(:shuffled_overview_keyword) { create(:shuffled_overview_keyword) }
+
+  context 'validations' do
+    it 'is valid with valid shuffled_overview and keyword' do
+      shuffled_overview_keyword = build(:shuffled_overview_keyword, shuffled_overview: shuffled_overview, keyword: keyword)
+      expect(shuffled_overview_keyword).to be_valid
+    end
+
+    it 'is not valid if the same keyword is added to the same shuffled_overview more than once' do
+      # 同じ組み合わせを作成
+      create(:shuffled_overview_keyword, shuffled_overview: shuffled_overview, keyword: keyword)
+      duplicate = build(:shuffled_overview_keyword, shuffled_overview: shuffled_overview, keyword: keyword)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:keyword_id]).to include("has already been added to this shuffled overview")
+    end
+  end
+
+  context 'associations' do
+    it 'belongs to shuffled_overview' do
+      association = described_class.reflect_on_association(:shuffled_overview)
+      expect(association.macro).to eq :belongs_to
+    end
+
+    it 'belongs to keyword' do
+      association = described_class.reflect_on_association(:keyword)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
+end


### PR DESCRIPTION
## GitHub Issue Ticket
- close #201

## やった事
`このプルリクエストにて何をしたのか？`
ShuffledOverviewKeywordモデルのモデルスペック
```ruby
class ShuffledOverviewKeyword < ApplicationRecord
  ## validation
  validates :keyword_id, uniqueness: { scope: :shuffled_overview_id, message: "has already been added to this shuffled overview" }
  # 特定の ShuffledOverview に対して Keyword が一意である

  ## association
  belongs_to :shuffled_overview
  belongs_to :keyword
end
``` 
### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`
下記コマンドでテスト実行、テストパスを確認
```
docker-compose run web bundle exec rspec spec/models/shuffled_overview_keyword_spec.rb
``` 

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
