### PR TITLE
Test_2024.09.21.08.25_Notificationモデルのモデルスペックテストを実装

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,6 +4,6 @@ class Notification < ApplicationRecord
   belongs_to :movie, optional: true
   # belongs_to :comment, optional: true
 
-  belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id', optional: true
-  belongs_to :visited, class_name: 'User', foreign_key: 'visited_id', optional: true
+  belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id'
+  belongs_to :visited, class_name: 'User', foreign_key: 'visited_id'
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,8 +1,16 @@
 FactoryBot.define do
   factory :notification do
-    visitor { association(:user) }
-    visited { association(:user) }  # 通知の受信者を定義
+    association :visitor, factory: :user
+    association :visited, factory: :user
     action { "bookmarked" }
     checked { false }
+
+    trait :with_shuffled_overview do
+      association :shuffled_overview
+    end
+
+    trait :with_movie do
+      association :movie
+    end
   end
 end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  let(:visitor) { create(:user) }
+  let(:visited) { create(:user) }
+  let(:notification) { build(:notification, visitor: visitor, visited: visited) }
+
+  context 'validations' do
+    it 'is valid with valid attributes' do
+      expect(notification).to be_valid
+    end
+
+    it 'is not valid without a visitor' do
+      notification.visitor = nil
+      expect(notification).not_to be_valid
+    end
+
+    it 'is not valid without a visited user' do
+      notification.visited = nil
+      expect(notification).not_to be_valid
+    end
+
+    it 'has a default value of false for checked' do
+      expect(notification.checked).to be_falsey
+    end
+  end
+
+  context 'associations' do
+    it 'belongs to a visitor' do
+      association = described_class.reflect_on_association(:visitor)
+      expect(association.macro).to eq :belongs_to
+      expect(association.options[:class_name]).to eq 'User'
+    end
+
+    it 'belongs to a visited' do
+      association = described_class.reflect_on_association(:visited)
+      expect(association.macro).to eq :belongs_to
+      expect(association.options[:class_name]).to eq 'User'
+    end
+
+    it 'can belong to a shuffled overview' do
+      association = described_class.reflect_on_association(:shuffled_overview)
+      expect(association.macro).to eq :belongs_to
+    end
+
+    it 'can belong to a movie' do
+      association = described_class.reflect_on_association(:movie)
+      expect(association.macro).to eq :belongs_to
+    end
+  end
+
+  context 'scopes' do
+    it 'orders by created_at in descending order' do
+      older_notification = create(:notification, created_at: 1.day.ago)
+      newer_notification = create(:notification, created_at: 1.hour.ago)
+
+      notifications = Notification.all
+      expect(notifications.first).to eq newer_notification
+    end
+  end
+end


### PR DESCRIPTION
## GitHub Issue Ticket
- close #205 

## やった事
`このプルリクエストにて何をしたのか？`
Notificationモデルのモデルスペックテストを実行
```ruby
class Notification < ApplicationRecord
  default_scope -> { order(created_at: :desc) }
  belongs_to :shuffled_overview, optional: true
  belongs_to :movie, optional: true
  # belongs_to :comment, optional: true

  belongs_to :visitor, class_name: 'User', foreign_key: 'visitor_id'
  belongs_to :visited, class_name: 'User', foreign_key: 'visited_id'
end
``` 

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

下記コマンドでテスト実行、テストパスを確認
```
docker-compose run web bundle exec rspec spec/models/notification_spec.rb
``` 

## Refs (レビューにあたって参考にすべき情報）(Optional)
`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
