### PR TITLE
Feature 2024.09.22.12.12 アカウント登録画面にアイコン登録フォームを追加する_#221

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,10 @@ class ApplicationController < ActionController::Base
 
   # Deviseのストロングパラメーターの設定
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :password_confirmation, :avatar])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
   end
-
+  
   # メソッドをDeviseのコールバックに追加
   before_action :configure_permitted_parameters, if: :devise_controller?
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,6 +15,17 @@
     </div>
 
     <div class="form-group">
+      <i class="fas fa-user-circle icon"></i>
+      <%= f.file_field :avatar, class: 'form-control', placeholder: 'アイコン', id: 'avatar-upload' %>
+      <% if resource.errors[:avatar].any? %>
+        <div class="error-message"><%= resource.errors[:avatar].first %></div>
+      <% end %>
+    </div>
+    <div class="image-preview">
+      <img id="avatar-preview" src="#" alt="アバタープレビュー" style="display: none;" />
+    </div>
+  
+    <div class="form-group">
       <i class="fas fa-envelope icon"></i>
       <%= f.email_field :email, class: 'form-control', placeholder: 'メールアドレス' %>
       <% if resource.errors[:email].any? %>
@@ -43,3 +54,37 @@
     </div>
   <% end %>
 </div>
+
+<style>
+#avatar-preview {
+  max-width: 100px;
+  max-height: 100px;
+  border-radius: 50%; /* 円形にするために50%を指定 */
+  position: relative;
+  left: 120px;
+  margin-bottom: 10px;
+}
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const avatarInput = document.getElementById('avatar-upload');
+  const avatarPreview = document.getElementById('avatar-preview');
+
+  avatarInput.addEventListener('change', function(event) {
+    const file = event.target.files[0];
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = function(e) {
+        avatarPreview.src = e.target.result;
+        avatarPreview.style.display = 'block';
+      };
+      reader.readAsDataURL(file);
+    } else {
+      avatarPreview.src = '#';
+      avatarPreview.style.display = 'none';
+    }
+  });
+});
+</script>


### PR DESCRIPTION
## GitHub Issue Ticket
- close #221 

## やった事
`このプルリクエストにて何をしたのか？`
アカウント登録画面にアイコン登録フォームを追加

### なぜやるのか

`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`

`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

## 動作確認

`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
