### PR TITLE
Build_2024.09.28.14.46_TMDB_API_KEYをcredentialから読み込むよう変更

### DIFF
--- a/config/initializers/tmdb.rb
+++ b/config/initializers/tmdb.rb
@@ -1,2 +1,2 @@
-TMDB_API_KEY = ENV['TMDB_API_KEY']
+TMDB_API_KEY = <%= Rails.application.credentials.tmdb[:tmdb_api_key] %>
 TMDB_BASE_URL = 'https://api.themoviedb.org/3'


### PR DESCRIPTION
## GitHub Issue Ticket
- close #243 

## やった事
`このプルリクエストにて何をしたのか？`
 - 変更前
   - TMDB_API_KEYをENVから読み取り
 - 変更後
   - TMDB_API_KEYをcredentialから読み取り

### なぜやるのか
`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`
`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`
本番環境でcredentialにより環境変数を読み取りをしているため

## 動作確認
`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
