### PR TITLE
Build_2024.09.28.17.55_TMDB_API_KEYをcredentialから読み込むよう変更

### DIFF
--- a/config/initializers/tmdb.rb
+++ b/config/initializers/tmdb.rb
@@ -1,2 +1,2 @@
-TMDB_API_KEY = <%= Rails.application.credentials.tmdb[:tmdb_api_key] %>
+TMDB_API_KEY = Rails.application.credentials.tmdb[:api_key]
 TMDB_BASE_URL = 'https://api.themoviedb.org/3'


### PR DESCRIPTION
## GitHub Issue Ticket

- close #243 

## やった事
`このプルリクエストにて何をしたのか？`
下記のエラーの解消
```
[ec2-user@ip-10-0-10-10 plotforge]$ docker-compose run app rails assets:precompile RAILS_ENV=production
WARN[0000] /plotforge/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] Found orphan containers ([plotforge-app-run-0090e8fa7299 plotforge-app-run-2030ee2510f6 plotforge-app-run-39d2cdbcd4e8 plotforge-app-run-cae50e0565bb plotforge-app-run-185caaf2d60e plotforge-app-run-bf87ba311e5d plotforge-app-run-641db92b2441 plotforge-app-run-028012f9fcd7]) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up. 
bin/rails aborted!
SyntaxError: /plotforge/config/initializers/tmdb.rb:1: syntax error, unexpected '<'
TMDB_API_KEY = <%= Rails.application.credenti...
               ^
/plotforge/config/environment.rb:5:in `<main>'
Tasks: TOP => environment
(See full trace by running task with --trace)

``` 

### なぜやるのか

`GitHub Issue で説明できない捕捉的な事項 (GitHub Issue の説明で十分であればここは不要)`

`なぜこのプルリクエストが必要と考えたかについて説明があるとレビュワーがわかりやすい`

## 動作確認

`どの環境でどんな動作チェックをしたか`
`動作確認をした事についてスクショなどがあるとわかりやすくて良い`

## Refs (レビューにあたって参考にすべき情報）(Optional)

`関連するプルリクエストやイシュー、コンフルリンクなど、レビュワーがレビューするにあたっての補足情報`
